### PR TITLE
Remove wolf - cheats 

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -652,9 +652,8 @@ void MainWindow::CreateConnects() {
                     new CheatsPatches(empty, empty, empty, empty, empty, nullptr);
                 connect(cheatsPatches, &CheatsPatches::downloadFinished, onDownloadFinished);
 
-                pendingDownloads += 3;
+                pendingDownloads += 2;
 
-                cheatsPatches->downloadCheats("wolf2022", gameSerial, gameVersion, false);
                 cheatsPatches->downloadCheats("GoldHEN", gameSerial, gameVersion, false);
                 cheatsPatches->downloadCheats("shadPS4", gameSerial, gameVersion, false);
             }


### PR DESCRIPTION
The wolf2022 cheats were removed in [PR-3432](https://github.com/shadps4-emu/shadPS4/pull/3432) from the shadps4 repository, but a remnant of that menu remains, allowing users to download cheats for all games at once.

<img width="744" height="333" alt="image" src="https://github.com/user-attachments/assets/4bcf0d23-bee2-43ac-9d1d-5566c921562a" />
