### PR TITLE
Version Manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,9 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/hotkeys.h
            src/qt_gui/hotkeys.cpp
            src/qt_gui/hotkeys.ui
+           src/qt_gui/version_dialog.cpp
+           src/qt_gui/version_dialog.h
+           src/qt_gui/version_dialog.ui
            ${RESOURCE_FILES}
            ${TRANSLATIONS}
            ${UPDATER}

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -131,6 +131,7 @@ static auto UserPaths = [] {
     create_path(PathType::MetaDataDir, user_dir / METADATA_DIR);
     create_path(PathType::CustomTrophy, user_dir / CUSTOM_TROPHY);
     create_path(PathType::CustomConfigs, user_dir / CUSTOM_CONFIGS);
+    create_path(PathType::VersionDir, user_dir / VERSION_DIR);
 
     std::ofstream notice_file(user_dir / CUSTOM_TROPHY / "Notice.txt");
     if (notice_file.is_open()) {

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -26,6 +26,7 @@ enum class PathType {
     MetaDataDir,    // Where game metadata (e.g. trophies and menu backgrounds) is stored.
     CustomTrophy,   // Where custom files for trophies are stored.
     CustomConfigs,  // Where custom files for different games are stored.
+    VersionDir,     // Where emulator versions are stored.
 };
 
 constexpr auto PORTABLE_DIR = "user";
@@ -44,6 +45,7 @@ constexpr auto PATCHES_DIR = "patches";
 constexpr auto METADATA_DIR = "game_data";
 constexpr auto CUSTOM_TROPHY = "custom_trophy";
 constexpr auto CUSTOM_CONFIGS = "custom_configs";
+constexpr auto VERSION_DIR = "versions";
 
 // Filenames
 constexpr auto LOG_FILE = "shad_log.txt";

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -32,7 +32,7 @@ CheckUpdate::CheckUpdate(std::shared_ptr<gui_settings> gui_settings, const bool 
                          QWidget* parent)
     : QDialog(parent), m_gui_settings(std::move(gui_settings)),
       networkManager(new QNetworkAccessManager(this)) {
-    setWindowTitle(tr("Auto Updater"));
+    setWindowTitle(tr("Auto Updater - Interface"));
     setFixedSize(0, 0);
     CheckForUpdates(showMessage);
 }
@@ -194,7 +194,7 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
     imageLabel->setScaledContents(true);
     imageLabel->setFixedSize(50, 50);
 
-    QLabel* titleLabel = new QLabel("<h1>" + tr("Update Available") + "</h1>", this);
+    QLabel* titleLabel = new QLabel("<h1>" + tr("Update Available (Interface)") + "</h1>", this);
     titleLayout->addWidget(imageLabel);
     titleLayout->addWidget(titleLabel);
     layout->addLayout(titleLayout);

--- a/src/qt_gui/game_install_dialog.h
+++ b/src/qt_gui/game_install_dialog.h
@@ -7,6 +7,7 @@
 
 #include "common/config.h"
 #include "common/path_util.h"
+#include "gui_settings.h"
 
 class QLineEdit;
 
@@ -19,14 +20,18 @@ public:
 private slots:
     void BrowseGamesDirectory();
     void BrowseAddonsDirectory();
+    void BrowseVersionDirectory();
 
 private:
     QWidget* SetupGamesDirectory();
     QWidget* SetupAddonsDirectory();
     QWidget* SetupDialogActions();
+    QWidget* SetupVersionDirectory();
     void Save();
+    std::shared_ptr<gui_settings> m_gui_settings;
 
 private:
     QLineEdit* m_gamesDirectory;
     QLineEdit* m_addonsDirectory;
+    QLineEdit* m_versionDirectory;
 };

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -24,7 +24,7 @@ const gui_value gen_guiLanguage = gui_value(general_settings, "guiLanguage", "en
 const gui_value gen_elfDirs =
     gui_value(main_window, "elfDirs", QVariant::fromValue(QList<QString>()));
 const gui_value gen_theme = gui_value(general_settings, "theme", 0);
-const gui_value gen_shadPath = gui_value(main_window, "shadPath", "");
+
 // main window settings
 const gui_value mw_geometry = gui_value(main_window, "geometry", QByteArray());
 const gui_value mw_showLabelsUnderIcons = gui_value(main_window, "showLabelsUnderIcons", true);
@@ -46,6 +46,10 @@ const gui_value gg_slider_pos = gui_value(game_grid, "slider_pos", 0);
 // favorites list
 const gui_value favorites_list =
     gui_value(favorites, "favoritesList", QVariant::fromValue(QList<QString>()));
+
+// version manager
+const gui_value vm_versionPath = gui_value(main_window, "versionPath", "");
+const gui_value vm_versionSelected = gui_value(main_window, "versionSelected", "");
 
 } // namespace gui
 

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -13,6 +13,7 @@ const QString main_window = "main_window";
 const QString game_list = "game_list";
 const QString game_grid = "game_grid";
 const QString favorites = "favorites";
+const QString version_manager = "version_manager";
 
 // general
 const gui_value gen_checkForUpdates = gui_value(general_settings, "checkForUpdates", false);
@@ -48,8 +49,10 @@ const gui_value favorites_list =
     gui_value(favorites, "favoritesList", QVariant::fromValue(QList<QString>()));
 
 // version manager
-const gui_value vm_versionPath = gui_value(main_window, "versionPath", "");
-const gui_value vm_versionSelected = gui_value(main_window, "versionSelected", "");
+const gui_value vm_versionPath = gui_value(version_manager, "versionPath", "");
+const gui_value vm_versionSelected = gui_value(version_manager, "versionSelected", "");
+const gui_value vm_showChangeLog = gui_value(version_manager, "showChangeLog", "");
+const gui_value vm_checkOnStartup = gui_value(version_manager, "checkOnStartup", "");
 
 } // namespace gui
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -57,7 +57,7 @@ bool MainWindow::Init() {
     SetLastUsedTheme();
     SetLastIconSizeBullet();
     // show ui
-    setMinimumSize(850, 405);
+    setMinimumSize(900, 405);
     std::string window_title = "";
     std::string remote_url(Common::g_scm_remote_url);
     std::string remote_host = Common::GetRemoteNameFromLink();
@@ -84,6 +84,11 @@ bool MainWindow::Init() {
     // Check for update
     CheckUpdateMain(true);
 #endif
+
+    if (m_gui_settings->GetValue(gui::vm_checkOnStartup).toBool()) {
+        auto versionDialog = new VersionDialog(m_gui_settings, this);
+        versionDialog->checkUpdatePre(false);
+    }
 
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -1335,17 +1340,19 @@ void MainWindow::RestartEmulator() {
 }
 
 void MainWindow::LoadVersionComboBox() {
-    QString path = m_gui_settings->GetValue(gui::vm_versionPath).toString();
-    if (path.isEmpty() || !QDir(path).exists())
-        return;
-
     QString savedVersionPath = m_gui_settings->GetValue(gui::vm_versionSelected).toString();
     if (savedVersionPath.isEmpty() || !QDir(savedVersionPath).exists()) {
         ui->versionComboBox->clear();
         ui->versionComboBox->addItem(tr("No version selected"));
         ui->versionComboBox->setCurrentIndex(0);
+        ui->versionComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+        ui->versionComboBox->adjustSize();
         return;
     }
+
+    QString path = m_gui_settings->GetValue(gui::vm_versionPath).toString();
+    if (path.isEmpty() || !QDir(path).exists())
+        return;
 
     ui->versionComboBox->clear();
 
@@ -1418,4 +1425,7 @@ void MainWindow::LoadVersionComboBox() {
                 QString fullPath = ui->versionComboBox->itemData(index).toString();
                 m_gui_settings->SetValue(gui::vm_versionSelected, fullPath);
             });
+
+    ui->versionComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    ui->versionComboBox->adjustSize();
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -80,6 +80,7 @@ bool MainWindow::Init() {
     this->show();
     // load game list
     LoadGameLists();
+
 #ifdef ENABLE_UPDATER
     // Check for update
     CheckUpdateMain(true);
@@ -1258,12 +1259,12 @@ void MainWindow::StartEmulator(std::filesystem::path path, QStringList args) {
 
     QString selectedVersion = m_gui_settings->GetValue(gui::vm_versionSelected).toString();
     if (selectedVersion.isEmpty()) {
-        QMessageBox::warning(
-            this, tr("No Version Selected"),
-            // clang-format off
-tr("First, download an emulator version by selecting one from the download screen."));
+        QMessageBox::warning(this, tr("No Version Selected"),
+                             // clang-format off
+tr("No emulator version was selected.\nThe Version Manager menu will then open.\nSelect an emulator version from the right panel."));
         // clang-format on
         auto versionDialog = new VersionDialog(m_gui_settings, this);
+        connect(versionDialog, &QDialog::finished, this, [this](int) { LoadVersionComboBox(); });
         versionDialog->exec();
         return;
     }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1336,7 +1336,11 @@ void MainWindow::RestartEmulator() {
 
 void MainWindow::LoadVersionComboBox() {
     QString path = m_gui_settings->GetValue(gui::vm_versionPath).toString();
-    if (path.isEmpty() || !QDir(path).exists()) {
+    if (path.isEmpty() || !QDir(path).exists())
+        return;
+
+    QString savedVersionPath = m_gui_settings->GetValue(gui::vm_versionSelected).toString();
+    if (savedVersionPath.isEmpty() || !QDir(savedVersionPath).exists()) {
         ui->versionComboBox->clear();
         ui->versionComboBox->addItem(tr("No version selected"));
         ui->versionComboBox->setCurrentIndex(0);
@@ -1350,8 +1354,6 @@ void MainWindow::LoadVersionComboBox() {
 
     QVector<QPair<QVector<int>, QString>> versionedDirs;
     QStringList otherDirs;
-
-    QString savedVersionPath = m_gui_settings->GetValue(gui::vm_versionSelected).toString();
 
     for (const QString& folder : folders) {
         if (folder == "Pre-release") {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -11,6 +11,7 @@
 
 #include "about_dialog.h"
 #include "cheats_patches.h"
+#include "version_dialog.h"
 #ifdef ENABLE_UPDATER
 #include "check_update.h"
 #endif
@@ -499,9 +500,15 @@ void MainWindow::CreateConnects() {
     });
 #endif
 
+    // connect(ui->aboutAct, &QAction::triggered, this, [this]() {
+    //     auto aboutDialog = new AboutDialog(m_gui_settings, this);
+    //     aboutDialog->exec();
+    // });
+
+    // connect(ui->aboutAct, &QPushButton::clicked, this, [this]() {
     connect(ui->aboutAct, &QAction::triggered, this, [this]() {
-        auto aboutDialog = new AboutDialog(m_gui_settings, this);
-        aboutDialog->exec();
+        auto versionDialog = new VersionDialog(m_gui_settings, this);
+        versionDialog->exec();
     });
 
     connect(ui->configureHotkeys, &QAction::triggered, this, [this]() {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -39,6 +39,7 @@ public:
     void PauseGame();
     void StopGame();
     void RestartGame();
+    void LoadVersionComboBox();
     bool showLabels;
 
 private Q_SLOTS:

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -52,6 +52,8 @@ public:
     QPushButton* keyboardButton;
     QPushButton* fullscreenButton;
     QPushButton* restartButton;
+    QPushButton* versionManagerdButton;
+    QComboBox* versionComboBox;
 
     QWidget* sizeSliderContainer;
     QHBoxLayout* sizeSliderContainer_layout;
@@ -343,6 +345,15 @@ public:
         menuHelp->addAction(updaterAct);
 #endif
         menuHelp->addAction(aboutAct);
+
+        versionComboBox = new QComboBox(centralWidget);
+        versionComboBox->setObjectName("versionComboBox");
+        versionComboBox->setMinimumWidth(100);
+
+        versionManagerdButton = new QPushButton(centralWidget);
+        versionManagerdButton->setFlat(true);
+        versionManagerdButton->setIcon(QIcon(":images/folder_icon.png"));
+        versionManagerdButton->setIconSize(QSize(40, 40));
 
         retranslateUi(MainWindow);
 

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -52,7 +52,7 @@ public:
     QPushButton* keyboardButton;
     QPushButton* fullscreenButton;
     QPushButton* restartButton;
-    QPushButton* versionManagerdButton;
+    QPushButton* versionManagerButton;
     QComboBox* versionComboBox;
 
     QWidget* sizeSliderContainer;
@@ -349,11 +349,7 @@ public:
         versionComboBox = new QComboBox(centralWidget);
         versionComboBox->setObjectName("versionComboBox");
         versionComboBox->setMinimumWidth(100);
-
-        versionManagerdButton = new QPushButton(centralWidget);
-        versionManagerdButton->setFlat(true);
-        versionManagerdButton->setIcon(QIcon(":images/folder_icon.png"));
-        versionManagerdButton->setIconSize(QSize(40, 40));
+        versionManagerButton = new QPushButton(centralWidget);
 
         retranslateUi(MainWindow);
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -3,12 +3,14 @@
 
 #include <vector>
 #include <QCompleter>
+#include <QDesktopServices>
 #include <QDirIterator>
 #include <QFileDialog>
 #include <QHoverEvent>
 #include <QMessageBox>
 #include <SDL3/SDL.h>
 #include <fmt/format.h>
+#include <toml.hpp>
 
 #include "common/config.h"
 #include "common/logging/log.h"
@@ -17,8 +19,6 @@
 #ifdef ENABLE_UPDATER
 #include "check_update.h"
 #endif
-#include <QDesktopServices>
-#include <toml.hpp>
 #include "background_music_player.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
@@ -362,19 +362,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
                 delete selected_item;
             }
         });
-        connect(ui->browse_shad_path, &QPushButton::clicked, this, [this]() {
-            const auto shad_exe_path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
-            QString initial_path;
 
-            QString shad_folder_path_string = QFileDialog::getOpenFileName(
-                this, tr("Select the shadPS4 executable"), initial_path);
-
-            auto file_path = Common::FS::PathFromQString(shad_folder_path_string);
-            if (!file_path.empty()) {
-                ui->currentShadPath->setText(shad_folder_path_string);
-                m_gui_settings->SetValue(gui::gen_shadPath, shad_folder_path_string);
-            }
-        });
         connect(ui->browseButton, &QPushButton::clicked, this, [this]() {
             const auto save_data_path = Config::GetSaveDataPath();
             QString initial_path;
@@ -515,8 +503,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->gameFoldersGroupBox->installEventFilter(this);
         ui->gameFoldersListWidget->installEventFilter(this);
         ui->addFolderButton->installEventFilter(this);
-        ui->removeFolderButton->installEventFilter(this);
-        ui->currentShadPath->setText(m_gui_settings->GetValue(gui::gen_shadPath).toString());
+        ui->removeFolderButton->installEventFilter(this);        
         ui->saveDataGroupBox->installEventFilter(this);
         ui->currentSaveDataPath->installEventFilter(this);
         ui->currentDLCFolder->installEventFilter(this);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -503,7 +503,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->gameFoldersGroupBox->installEventFilter(this);
         ui->gameFoldersListWidget->installEventFilter(this);
         ui->addFolderButton->installEventFilter(this);
-        ui->removeFolderButton->installEventFilter(this);        
+        ui->removeFolderButton->installEventFilter(this);
         ui->saveDataGroupBox->installEventFilter(this);
         ui->currentSaveDataPath->installEventFilter(this);
         ui->currentDLCFolder->installEventFilter(this);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -618,8 +618,6 @@ void SettingsDialog::LoadValuesFromConfig() {
 
     // Entries with no game-specific settings
     if (!is_game_specific) {
-        ui->currentShadPath->setText(m_gui_settings->GetValue(gui::gen_shadPath).toString());
-
         const auto save_data_path = Config::GetSaveDataPath();
         QString save_data_path_string;
         Common::FS::PathToQString(save_data_path_string, save_data_path);

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>5</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -76,8 +76,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>536</height>
+         <width>579</width>
+         <height>482</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -320,8 +320,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>408</width>
-                       <height>68</height>
+                       <width>98</width>
+                       <height>47</height>
                       </rect>
                      </property>
                      <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -422,8 +422,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>932</width>
-         <height>507</height>
+         <width>946</width>
+         <height>516</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -1033,8 +1033,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>536</height>
+         <width>809</width>
+         <height>353</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1440,8 +1440,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>536</height>
+         <width>497</width>
+         <height>348</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1656,7 +1656,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0">
@@ -1942,7 +1942,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -1985,39 +1985,6 @@
            </item>
            <item>
             <widget class="QListWidget" name="gameFoldersListWidget"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="shadps4GroupBox">
-          <property name="title">
-           <string>shadPS4 Path</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_shadps4">
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_shadps4">
-             <item>
-              <widget class="QLineEdit" name="currentShadPath">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="placeholderText">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="browse_shad_path">
-               <property name="text">
-                <string>Browse</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
            </item>
           </layout>
          </widget>
@@ -2143,8 +2110,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>536</height>
+         <width>292</width>
+         <height>299</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2289,8 +2256,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>234</height>
+         <width>565</width>
+         <height>229</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2464,8 +2431,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>287</height>
+         <width>427</width>
+         <height>402</height>
         </rect>
        </property>
        <property name="sizePolicy">

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -1,0 +1,502 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <QDir>
+#include <QFileDialog>
+#include <QInputDialog>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QProcess>
+#include <QProgressBar>
+#include <QRegularExpression>
+#include <QTextStream>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <common/path_util.h>
+
+#include "common/config.h"
+#include "gui_settings.h"
+#include "ui_version_dialog.h"
+#include "version_dialog.h"
+
+VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
+    : QDialog(parent), ui(new Ui::VersionDialog), m_gui_settings(std::move(gui_settings)) {
+    ui->setupUi(this);
+
+    ui->currentShadPath->setText(m_gui_settings->GetValue(gui::gen_shadPath).toString());
+    connect(ui->browse_shad_path, &QPushButton::clicked, this, [this]() {
+        const auto shad_exe_path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
+        QString initial_path = shad_exe_path;
+
+        QString shad_folder_path_string =
+            QFileDialog::getExistingDirectory(this, tr("Select the shadPS4 folder"), initial_path);
+
+        auto folder_path = Common::FS::PathFromQString(shad_folder_path_string);
+        if (!folder_path.empty()) {
+            ui->currentShadPath->setText(shad_folder_path_string);
+            m_gui_settings->SetValue(gui::gen_shadPath, shad_folder_path_string);
+        }
+    });
+
+    LoadinstalledList();
+
+    connect(ui->checkChangesVersionButton, &QPushButton::clicked, this,
+            [this]() { LoadinstalledList(); });
+
+    connect(ui->addCustomVersionButton, &QPushButton::clicked, this, [this]() {
+        QString exePath;
+
+#ifdef Q_OS_WIN
+        exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
+                                               tr("Executable (*.exe)"));
+#elif defined(Q_OS_LINUX)
+    exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
+                                            tr("Executable (*.AppImage)"));
+#elif defined(Q_OS_MACOS)
+    exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
+                                            tr("Executable (*.*)"));
+#endif
+
+        if (exePath.isEmpty())
+            return;
+
+        bool ok;
+        QString folderName =
+            QInputDialog::getText(this, tr("Version name"),
+                                  tr("Enter the name of this version as it appears in the list."),
+                                  QLineEdit::Normal, "", &ok);
+        if (!ok || folderName.trimmed().isEmpty())
+            return;
+
+        folderName = folderName.trimmed();
+
+        QString basePath = m_gui_settings->GetValue(gui::gen_shadPath).toString();
+        QString newFolderPath = QDir(basePath).filePath(folderName);
+
+        QDir dir;
+        if (dir.exists(newFolderPath)) {
+            QMessageBox::warning(this, tr("Error"), tr("A folder with that name already exists."));
+            return;
+        }
+
+        if (!dir.mkpath(newFolderPath)) {
+            QMessageBox::critical(this, tr("Error"), tr("Failed to create folder."));
+            return;
+        }
+
+        QFileInfo exeInfo(exePath);
+        QString targetFilePath = QDir(newFolderPath).filePath(exeInfo.fileName());
+
+        if (!QFile::copy(exePath, targetFilePath)) {
+            QMessageBox::critical(this, tr("Error"), tr("Failed to copy executable."));
+            return;
+        }
+
+        QMessageBox::information(this, tr("Success"), tr("Version added successfully."));
+        LoadinstalledList();
+    });
+
+    connect(ui->deleteVersionButton, &QPushButton::clicked, this, [this]() {
+        QTreeWidgetItem* selectedItem = ui->installedTreeWidget->currentItem();
+        if (!selectedItem) {
+            QMessageBox::warning(this, tr("Notice"),
+                                 tr("No version selected from the Installed list."));
+            return;
+        }
+
+        QString folderName = selectedItem->text(0);
+        QString path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
+        QString fullPath = QDir(path).filePath(folderName);
+
+        auto reply = QMessageBox::question(this, tr("Delete version"),
+                                           tr("Do you want to delete the version") +
+                                               QString(" \"%1\" ?").arg(folderName),
+                                           QMessageBox::Yes | QMessageBox::No);
+        if (reply == QMessageBox::Yes) {
+            QDir dirToRemove(fullPath);
+            if (dirToRemove.exists()) {
+                if (!dirToRemove.removeRecursively()) {
+                    QMessageBox::critical(this, tr("Error"),
+                                          tr("Failed to delete folder.") +
+                                              QString("\n \"%1\"").arg(folderName));
+                    return;
+                }
+            }
+            LoadinstalledList();
+        }
+    });
+
+    connect(ui->checkVersionDownloadButton, &QPushButton::clicked, this, [this]() {
+        QNetworkAccessManager* manager = new QNetworkAccessManager(this);
+        QUrl url("https://api.github.com/repos/shadps4-emu/shadPS4/tags");
+        QNetworkRequest request(url);
+        QNetworkReply* reply = manager->get(request);
+
+        connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+            if (reply->error() == QNetworkReply::NoError) {
+                QByteArray response = reply->readAll();
+                QJsonDocument doc = QJsonDocument::fromJson(response);
+                if (doc.isArray()) {
+                    QJsonArray tags = doc.array();
+                    ui->downloadTreeWidget->clear();
+
+                    QTreeWidgetItem* preReleaseItem = nullptr;
+                    QList<QTreeWidgetItem*> otherItems;
+                    bool foundPreRelease = false;
+
+                    //  > v.0.5.0
+                    auto isVersionGreaterThan_0_5_0 = [](const QString& tagName) -> bool {
+                        QRegularExpression versionRegex(R"(v\.?(\d+)\.(\d+)\.(\d+))");
+                        QRegularExpressionMatch match = versionRegex.match(tagName);
+                        if (match.hasMatch()) {
+                            int major = match.captured(1).toInt();
+                            int minor = match.captured(2).toInt();
+                            int patch = match.captured(3).toInt();
+
+                            if (major > 0)
+                                return true;
+                            if (major == 0 && minor >= 5)
+                                return true;
+                            if (major == 0 && minor == 5 && patch > 0)
+                                return true;
+                        }
+                        return false;
+                    };
+
+                    for (const QJsonValue& value : tags) {
+                        QJsonObject tagObj = value.toObject();
+                        QString tagName = tagObj["name"].toString();
+
+                        if (tagName.startsWith("Pre-release", Qt::CaseInsensitive)) {
+                            if (!foundPreRelease) {
+                                preReleaseItem = new QTreeWidgetItem();
+                                preReleaseItem->setText(0, "Pre-release");
+                                foundPreRelease = true;
+                            }
+                            continue;
+                        }
+                        if (!isVersionGreaterThan_0_5_0(tagName)) {
+                            continue;
+                        }
+
+                        QTreeWidgetItem* item = new QTreeWidgetItem();
+                        item->setText(0, tagName);
+                        otherItems.append(item);
+                    }
+
+                    // If you didn't find Pre-release, add it manually
+                    if (!foundPreRelease) {
+                        preReleaseItem = new QTreeWidgetItem();
+                        preReleaseItem->setText(0, "Pre-release");
+                    }
+
+                    // Add Pre-release first
+                    if (preReleaseItem) {
+                        ui->downloadTreeWidget->addTopLevelItem(preReleaseItem);
+                    }
+
+                    // Add the others
+                    for (QTreeWidgetItem* item : otherItems) {
+                        ui->downloadTreeWidget->addTopLevelItem(item);
+                    }
+                    connect(
+                        ui->downloadTreeWidget, &QTreeWidget::itemClicked, this,
+                        [this](QTreeWidgetItem* item, int) {
+                            if (m_gui_settings->GetValue(gui::gen_shadPath).toString() == "") {
+
+                                QMessageBox::StandardButton reply;
+                                reply = QMessageBox::warning(
+                                    this, tr("Select the shadPS4 folder"),
+                                    // clang-format off
+tr("First you need to choose a location to save the versions in\n'Path to save versions'"));
+                                // clang-format on
+                                return;
+                            }
+                            QString versionName = item->text(0);
+                            QString apiUrl;
+                            QString platform;
+
+#ifdef Q_OS_WIN
+                            platform = "win64-sdl";
+#elif defined(Q_OS_LINUX)
+                                platform = "linux-sdl";
+#elif defined(Q_OS_MAC)
+                                platform = "macos-sdl";
+#endif
+                            if (versionName == "Pre-release") {
+                                apiUrl =
+                                    "https://api.github.com/repos/shadps4-emu/shadPS4/releases";
+                            } else {
+                                apiUrl = QString("https://api.github.com/repos/shadps4-emu/"
+                                                 "shadPS4/releases/tags/%1")
+                                             .arg(versionName);
+                            }
+
+                            { // Menssage yes/no
+                                QMessageBox::StandardButton reply;
+                                reply = QMessageBox::question(
+                                    this, tr("Download"),
+                                    tr("Do you want to download the version:") +
+                                        QString(" %1 ?").arg(versionName),
+                                    QMessageBox::Yes | QMessageBox::No);
+
+                                if (reply == QMessageBox::No)
+                                    return;
+                            }
+
+                            QNetworkAccessManager* manager = new QNetworkAccessManager(this);
+                            QNetworkRequest request(apiUrl);
+                            QNetworkReply* reply = manager->get(request);
+
+                            connect(
+                                reply, &QNetworkReply::finished, this,
+                                [this, reply, versionName, platform]() {
+                                    if (reply->error() != QNetworkReply::NoError) {
+                                        QMessageBox::warning(this, tr("Error"),
+                                                             reply->errorString());
+                                        reply->deleteLater();
+                                        return;
+                                    }
+
+                                    QByteArray response = reply->readAll();
+                                    QJsonDocument doc = QJsonDocument::fromJson(response);
+
+                                    QJsonArray assets;
+
+                                    if (versionName == "Pre-release") {
+                                        QJsonArray releases = doc.array();
+                                        for (const QJsonValue& val : releases) {
+                                            QJsonObject obj = val.toObject();
+                                            if (obj["prerelease"].toBool()) {
+                                                assets = obj["assets"].toArray();
+                                                break;
+                                            }
+                                        }
+                                    } else {
+                                        QJsonObject release = doc.object();
+                                        assets = release["assets"].toArray();
+                                    }
+
+                                    QString downloadUrl;
+                                    for (const QJsonValue& val : assets) {
+                                        QJsonObject obj = val.toObject();
+                                        QString name = obj["name"].toString();
+                                        if (name.contains(platform)) {
+                                            downloadUrl = obj["browser_download_url"].toString();
+                                            break;
+                                        }
+                                    }
+
+                                    if (downloadUrl.isEmpty()) {
+                                        QMessageBox::warning(
+                                            this, tr("Error"),
+                                            tr("No files available for this platform."));
+                                        reply->deleteLater();
+                                        return;
+                                    }
+
+                                    // Destination directory
+                                    QString userPath =
+                                        m_gui_settings->GetValue(gui::gen_shadPath).toString();
+                                    QString fileName = "temp_download_update.zip";
+                                    QString destinationPath = userPath + "/" + fileName;
+
+                                    // Start download
+                                    QNetworkAccessManager* downloadManager =
+                                        new QNetworkAccessManager(this);
+                                    QNetworkRequest downloadRequest(downloadUrl);
+                                    QNetworkReply* downloadReply =
+                                        downloadManager->get(downloadRequest);
+
+                                    QDialog* progressDialog = new QDialog(this);
+                                    progressDialog->setWindowTitle(tr("Downloading") +
+                                                                   QString(" %1").arg(versionName));
+                                    progressDialog->setFixedSize(400, 80);
+
+                                    QVBoxLayout* layout = new QVBoxLayout(progressDialog);
+                                    QProgressBar* progressBar = new QProgressBar(progressDialog);
+                                    progressBar->setRange(0, 100);
+                                    layout->addWidget(progressBar);
+                                    progressDialog->setLayout(layout);
+                                    progressDialog->show();
+
+                                    // Updates progress based on bytes downloaded
+                                    connect(downloadReply, &QNetworkReply::downloadProgress, this,
+                                            [progressBar](qint64 bytesReceived, qint64 bytesTotal) {
+                                                if (bytesTotal > 0)
+                                                    progressBar->setValue(static_cast<int>(
+                                                        (bytesReceived * 100) / bytesTotal));
+                                            });
+
+                                    QFile* file = new QFile(destinationPath);
+                                    if (!file->open(QIODevice::WriteOnly)) {
+                                        QMessageBox::warning(this, tr("Error"),
+                                                             tr("Could not save file."));
+                                        file->deleteLater();
+                                        downloadReply->deleteLater();
+                                        return;
+                                    }
+
+                                    connect(downloadReply, &QNetworkReply::readyRead, this,
+                                            [file, downloadReply]() {
+                                                file->write(downloadReply->readAll());
+                                            });
+
+                                    connect(
+                                        downloadReply, &QNetworkReply::finished, this,
+                                        [this, file, downloadReply, progressDialog, versionName]() {
+                                            file->flush();
+                                            file->close();
+
+                                            file->deleteLater();
+                                            downloadReply->deleteLater();
+
+                                            QString shadPath =
+                                                m_gui_settings->GetValue(gui::gen_shadPath)
+                                                    .toString();
+                                            QString zipPath =
+                                                shadPath + "/temp_download_update.zip";
+                                            QString destFolder = shadPath + "/" + versionName;
+
+                                            // script to extract ZIP
+                                            QString scriptFilePath;
+                                            QString scriptContent;
+                                            QStringList args;
+                                            QString process;
+#ifdef Q_OS_WIN
+                                            scriptFilePath = shadPath + "/extract_update.ps1";
+                                            scriptContent =
+                                                QString(
+                                                    "New-Item -ItemType Directory -Path \"%1\" "
+                                                    "-Force\n"
+                                                    "Expand-Archive -Path \"%2\" "
+                                                    "-DestinationPath \"%1\" -Force\n"
+                                                    "Remove-Item -Force \"%2\"\n" // delete ZIP
+                                                    "Remove-Item -Force \"%3\"\n" // delte script
+                                                    "cls\n")                      // clean console
+                                                    .arg(destFolder)
+                                                    .arg(zipPath)
+                                                    .arg(scriptFilePath);
+                                            process = "powershell.exe";
+                                            args << "-ExecutionPolicy" << "Bypass" << "-File"
+                                                 << scriptFilePath;
+
+#elif defined(Q_OS_LINUX) || defined(Q_OS_MAC)
+                                                scriptFilePath = shadPath + "/extract_update.sh";
+                                                scriptContent =
+                                                    QString("#!/bin/bash\n"
+                                                            "mkdir -p \"%1\"\n"
+                                                            "unzip -o \"%2\" -d \"%1\"\n"
+                                                            "rm \"%2\"\n" // delete ZIP
+                                                            "rm \"%3\"\n" // delte script
+                                                            "clear\n")    // clean console
+                                                        .arg(destFolder)
+                                                        .arg(zipPath)
+                                                        .arg(scriptFilePath);
+                                                process = "bash";
+                                                args << scriptFilePath;
+#endif
+                                            QFile scriptFile(scriptFilePath);
+                                            if (scriptFile.open(QIODevice::WriteOnly |
+                                                                QIODevice::Text)) {
+                                                QTextStream out(&scriptFile);
+#ifdef Q_OS_WIN
+                                                scriptFile.write("\xEF\xBB\xBF"); // BOM
+#endif
+                                                out << scriptContent;
+                                                scriptFile.close();
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
+                                                scriptFile.setPermissions(QFile::ExeUser |
+                                                                          QFile::ReadUser |
+                                                                          QFile::WriteUser);
+#endif
+
+                                                QProcess::startDetached(process, args);
+
+                                                // wait 4 seconds while extracting before message
+                                                QTimer::singleShot(
+                                                    4000, this,
+                                                    [this, versionName, destFolder,
+                                                     progressDialog]() {
+                                                        progressDialog->close();
+                                                        progressDialog->deleteLater();
+
+                                                        QMessageBox::information(
+                                                            this, tr("Download"),
+                                                            tr("Version %1 has been downloaded")
+                                                                .arg(versionName));
+
+                                                        VersionDialog::LoadinstalledList();
+                                                    });
+
+                                            } else {
+                                                QMessageBox::warning(
+                                                    this, tr("Error"),
+                                                    tr("Failed to create zip extraction script:") +
+                                                        QString("\n%1").arg(scriptFilePath));
+                                            }
+                                        });
+
+                                    reply->deleteLater();
+                                });
+                        });
+                }
+            } else {
+                QMessageBox::warning(this, tr("Error"),
+                                     tr("Error accessing GitHub API") +
+                                         QString(":\n%1").arg(reply->errorString()));
+            }
+            reply->deleteLater();
+        });
+    });
+}
+
+VersionDialog::~VersionDialog() {
+    delete ui;
+}
+
+void VersionDialog::LoadinstalledList() {
+    ui->installedTreeWidget->clear();
+
+    QString path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
+    QDir dir(path);
+    if (!dir.exists())
+        return;
+
+    QStringList folders = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    QRegularExpression versionRegex("^v\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+    QVector<QPair<QVector<int>, QString>> versionedDirs;
+    QStringList otherDirs;
+
+    for (const QString& folder : folders) {
+        QRegularExpressionMatch match = versionRegex.match(folder);
+        if (match.hasMatch()) {
+            QVector<int> versionParts;
+            for (int i = 1; i <= match.lastCapturedIndex(); ++i) {
+                versionParts.append(match.captured(i).toInt());
+            }
+            versionedDirs.append({versionParts, folder});
+        } else {
+            otherDirs.append(folder);
+        }
+    }
+
+    std::sort(otherDirs.begin(), otherDirs.end());
+    std::sort(versionedDirs.begin(), versionedDirs.end(),
+              [](const auto& a, const auto& b) { return a.first > b.first; });
+
+    for (const QString& folder : otherDirs) {
+        QTreeWidgetItem* item = new QTreeWidgetItem(ui->installedTreeWidget);
+        item->setText(0, folder);
+    }
+
+    for (const auto& pair : versionedDirs) {
+        QTreeWidgetItem* item = new QTreeWidgetItem(ui->installedTreeWidget);
+        item->setText(0, pair.second);
+    }
+}

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -341,8 +341,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
             { // Menssage yes/no
                 QMessageBox::StandardButton reply;
                 reply = QMessageBox::question(this, tr("Download"),
-                                              tr("Do you want to download the version:") +
-                                                  QString(" %1 ?").arg(versionName),
+                                              tr("Do you want to download the version") +
+                                                  QString(": %1 ?").arg(versionName),
                                               QMessageBox::Yes | QMessageBox::No);
                 if (reply == QMessageBox::No)
                     return;
@@ -404,7 +404,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                 QNetworkReply* downloadReply = downloadManager->get(downloadRequest);
 
                 QDialog* progressDialog = new QDialog(this);
-                progressDialog->setWindowTitle(tr("Downloading %1").arg(versionName));
+                progressDialog->setWindowTitle(
+                    tr("Downloading %1 , please wait...").arg(versionName));
                 progressDialog->setFixedSize(400, 80);
                 QVBoxLayout* layout = new QVBoxLayout(progressDialog);
                 QProgressBar* progressBar = new QProgressBar(progressDialog);
@@ -530,8 +531,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
 
                         } else {
                             QMessageBox::warning(this, tr("Error"),
-                                                 tr("Failed to create zip extraction script:") +
-                                                     QString("\n%1").arg(scriptFilePath));
+                                                 tr("Failed to create zip extraction script") +
+                                                     QString(":\n%1").arg(scriptFilePath));
                         }
                     });
                 reply->deleteLater();
@@ -782,7 +783,7 @@ void VersionDialog::checkUpdatePre(const bool showMessage) {
                     QMessageBox::StandardButton reply =
                         QMessageBox::question(this, tr("No pre-release found"),
                                               // clang-format off
-            tr("You don't have any pre-release installed yet. Would you like to download it now?"),
+            tr("You don't have any pre-release installed yet.\nWould you like to download it now?"),
                                               // clang-format on
                                               QMessageBox::Yes | QMessageBox::No);
                     if (reply == QMessageBox::Yes) {
@@ -901,7 +902,7 @@ void VersionDialog::requestChangelog(const QString& localHash, const QString& la
         reply, &QNetworkReply::finished, this, [this, reply, localHash, latestHash, outputView]() {
             if (reply->error() != QNetworkReply::NoError) {
                 QMessageBox::warning(this, tr("Error"),
-                                     tr("Network error while fetching changelog:") + "\n" +
+                                     tr("Network error while fetching changelog") + ":\n" +
                                          reply->errorString());
                 reply->deleteLater();
                 return;
@@ -1122,7 +1123,7 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
                 m_gui_settings->SetValue(gui::vm_versionSelected, destFolder);
 
                 QMessageBox::information(this, tr("Complete installation"),
-                                         tr("Pre-release updated successfully:") + "\n" + tagName);
+                                         tr("Pre-release updated successfully") + ":\n" + tagName);
 
                 LoadinstalledList();
             });

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -28,6 +28,16 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
     ui->setupUi(this);
 
     ui->currentShadPath->setText(m_gui_settings->GetValue(gui::gen_shadPath).toString());
+
+    LoadinstalledList();
+
+    QStringList cachedVersions = LoadDownloadCache();
+    if (!cachedVersions.isEmpty()) {
+        PopulateDownloadTree(cachedVersions);
+    } else {
+        DownloadListVersion();
+    }
+
     connect(ui->browse_shad_path, &QPushButton::clicked, this, [this]() {
         const auto shad_exe_path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
         QString initial_path = shad_exe_path;
@@ -41,8 +51,6 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
             m_gui_settings->SetValue(gui::gen_shadPath, shad_folder_path_string);
         }
     });
-
-    LoadinstalledList();
 
     connect(ui->checkChangesVersionButton, &QPushButton::clicked, this,
             [this]() { LoadinstalledList(); });
@@ -108,10 +116,13 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
             return;
         }
 
-        QString folderName = selectedItem->text(0);
-        QString path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
-        QString fullPath = QDir(path).filePath(folderName);
-
+        // Get the actual path of the invisible column folder
+        QString fullPath = selectedItem->text(3);
+        if (fullPath.isEmpty()) {
+            QMessageBox::critical(this, tr("Error"), tr("Failed to determine the folder path."));
+            return;
+        }
+        QString folderName = QDir(fullPath).dirName();
         auto reply = QMessageBox::question(this, tr("Delete version"),
                                            tr("Do you want to delete the version") +
                                                QString(" \"%1\" ?").arg(folderName),
@@ -130,356 +141,372 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
         }
     });
 
-    connect(ui->checkVersionDownloadButton, &QPushButton::clicked, this, [this]() {
-        QNetworkAccessManager* manager = new QNetworkAccessManager(this);
-        QUrl url("https://api.github.com/repos/shadps4-emu/shadPS4/tags");
-        QNetworkRequest request(url);
-        QNetworkReply* reply = manager->get(request);
-
-        connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-            if (reply->error() == QNetworkReply::NoError) {
-                QByteArray response = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(response);
-                if (doc.isArray()) {
-                    QJsonArray tags = doc.array();
-                    ui->downloadTreeWidget->clear();
-
-                    QTreeWidgetItem* preReleaseItem = nullptr;
-                    QList<QTreeWidgetItem*> otherItems;
-                    bool foundPreRelease = false;
-
-                    //  > v.0.5.0
-                    auto isVersionGreaterThan_0_5_0 = [](const QString& tagName) -> bool {
-                        QRegularExpression versionRegex(R"(v\.?(\d+)\.(\d+)\.(\d+))");
-                        QRegularExpressionMatch match = versionRegex.match(tagName);
-                        if (match.hasMatch()) {
-                            int major = match.captured(1).toInt();
-                            int minor = match.captured(2).toInt();
-                            int patch = match.captured(3).toInt();
-
-                            if (major > 0)
-                                return true;
-                            if (major == 0 && minor >= 5)
-                                return true;
-                            if (major == 0 && minor == 5 && patch > 0)
-                                return true;
-                        }
-                        return false;
-                    };
-
-                    for (const QJsonValue& value : tags) {
-                        QJsonObject tagObj = value.toObject();
-                        QString tagName = tagObj["name"].toString();
-
-                        if (tagName.startsWith("Pre-release", Qt::CaseInsensitive)) {
-                            if (!foundPreRelease) {
-                                preReleaseItem = new QTreeWidgetItem();
-                                preReleaseItem->setText(0, "Pre-release");
-                                foundPreRelease = true;
-                            }
-                            continue;
-                        }
-                        if (!isVersionGreaterThan_0_5_0(tagName)) {
-                            continue;
-                        }
-
-                        QTreeWidgetItem* item = new QTreeWidgetItem();
-                        item->setText(0, tagName);
-                        otherItems.append(item);
-                    }
-
-                    // If you didn't find Pre-release, add it manually
-                    if (!foundPreRelease) {
-                        preReleaseItem = new QTreeWidgetItem();
-                        preReleaseItem->setText(0, "Pre-release");
-                    }
-
-                    // Add Pre-release first
-                    if (preReleaseItem) {
-                        ui->downloadTreeWidget->addTopLevelItem(preReleaseItem);
-                    }
-
-                    // Add the others
-                    for (QTreeWidgetItem* item : otherItems) {
-                        ui->downloadTreeWidget->addTopLevelItem(item);
-                    }
-                    connect(
-                        ui->downloadTreeWidget, &QTreeWidget::itemClicked, this,
-                        [this](QTreeWidgetItem* item, int) {
-                            if (m_gui_settings->GetValue(gui::gen_shadPath).toString() == "") {
-
-                                QMessageBox::StandardButton reply;
-                                reply = QMessageBox::warning(
-                                    this, tr("Select the shadPS4 folder"),
-                                    // clang-format off
-tr("First you need to choose a location to save the versions in\n'Path to save versions'"));
-                                // clang-format on
-                                return;
-                            }
-                            QString versionName = item->text(0);
-                            QString apiUrl;
-                            QString platform;
-
-#ifdef Q_OS_WIN
-                            platform = "win64-sdl";
-#elif defined(Q_OS_LINUX)
-                                platform = "linux-sdl";
-#elif defined(Q_OS_MAC)
-                                platform = "macos-sdl";
-#endif
-                            if (versionName == "Pre-release") {
-                                apiUrl =
-                                    "https://api.github.com/repos/shadps4-emu/shadPS4/releases";
-                            } else {
-                                apiUrl = QString("https://api.github.com/repos/shadps4-emu/"
-                                                 "shadPS4/releases/tags/%1")
-                                             .arg(versionName);
-                            }
-
-                            { // Menssage yes/no
-                                QMessageBox::StandardButton reply;
-                                reply = QMessageBox::question(
-                                    this, tr("Download"),
-                                    tr("Do you want to download the version:") +
-                                        QString(" %1 ?").arg(versionName),
-                                    QMessageBox::Yes | QMessageBox::No);
-
-                                if (reply == QMessageBox::No)
-                                    return;
-                            }
-
-                            QNetworkAccessManager* manager = new QNetworkAccessManager(this);
-                            QNetworkRequest request(apiUrl);
-                            QNetworkReply* reply = manager->get(request);
-
-                            connect(
-                                reply, &QNetworkReply::finished, this,
-                                [this, reply, versionName, platform]() {
-                                    if (reply->error() != QNetworkReply::NoError) {
-                                        QMessageBox::warning(this, tr("Error"),
-                                                             reply->errorString());
-                                        reply->deleteLater();
-                                        return;
-                                    }
-
-                                    QByteArray response = reply->readAll();
-                                    QJsonDocument doc = QJsonDocument::fromJson(response);
-
-                                    QJsonArray assets;
-
-                                    if (versionName == "Pre-release") {
-                                        QJsonArray releases = doc.array();
-                                        for (const QJsonValue& val : releases) {
-                                            QJsonObject obj = val.toObject();
-                                            if (obj["prerelease"].toBool()) {
-                                                assets = obj["assets"].toArray();
-                                                break;
-                                            }
-                                        }
-                                    } else {
-                                        QJsonObject release = doc.object();
-                                        assets = release["assets"].toArray();
-                                    }
-
-                                    QString downloadUrl;
-                                    for (const QJsonValue& val : assets) {
-                                        QJsonObject obj = val.toObject();
-                                        QString name = obj["name"].toString();
-                                        if (name.contains(platform)) {
-                                            downloadUrl = obj["browser_download_url"].toString();
-                                            break;
-                                        }
-                                    }
-
-                                    if (downloadUrl.isEmpty()) {
-                                        QMessageBox::warning(
-                                            this, tr("Error"),
-                                            tr("No files available for this platform."));
-                                        reply->deleteLater();
-                                        return;
-                                    }
-
-                                    // Destination directory
-                                    QString userPath =
-                                        m_gui_settings->GetValue(gui::gen_shadPath).toString();
-                                    QString fileName = "temp_download_update.zip";
-                                    QString destinationPath = userPath + "/" + fileName;
-
-                                    // Start download
-                                    QNetworkAccessManager* downloadManager =
-                                        new QNetworkAccessManager(this);
-                                    QNetworkRequest downloadRequest(downloadUrl);
-                                    QNetworkReply* downloadReply =
-                                        downloadManager->get(downloadRequest);
-
-                                    QDialog* progressDialog = new QDialog(this);
-                                    progressDialog->setWindowTitle(tr("Downloading") +
-                                                                   QString(" %1").arg(versionName));
-                                    progressDialog->setFixedSize(400, 80);
-
-                                    QVBoxLayout* layout = new QVBoxLayout(progressDialog);
-                                    QProgressBar* progressBar = new QProgressBar(progressDialog);
-                                    progressBar->setRange(0, 100);
-                                    layout->addWidget(progressBar);
-                                    progressDialog->setLayout(layout);
-                                    progressDialog->show();
-
-                                    // Updates progress based on bytes downloaded
-                                    connect(downloadReply, &QNetworkReply::downloadProgress, this,
-                                            [progressBar](qint64 bytesReceived, qint64 bytesTotal) {
-                                                if (bytesTotal > 0)
-                                                    progressBar->setValue(static_cast<int>(
-                                                        (bytesReceived * 100) / bytesTotal));
-                                            });
-
-                                    QFile* file = new QFile(destinationPath);
-                                    if (!file->open(QIODevice::WriteOnly)) {
-                                        QMessageBox::warning(this, tr("Error"),
-                                                             tr("Could not save file."));
-                                        file->deleteLater();
-                                        downloadReply->deleteLater();
-                                        return;
-                                    }
-
-                                    connect(downloadReply, &QNetworkReply::readyRead, this,
-                                            [file, downloadReply]() {
-                                                file->write(downloadReply->readAll());
-                                            });
-
-                                    connect(
-                                        downloadReply, &QNetworkReply::finished, this,
-                                        [this, file, downloadReply, progressDialog, versionName]() {
-                                            file->flush();
-                                            file->close();
-
-                                            file->deleteLater();
-                                            downloadReply->deleteLater();
-
-                                            QString shadPath =
-                                                m_gui_settings->GetValue(gui::gen_shadPath)
-                                                    .toString();
-                                            QString zipPath =
-                                                shadPath + "/temp_download_update.zip";
-                                            QString destFolder = shadPath + "/" + versionName;
-
-                                            // script to extract ZIP
-                                            QString scriptFilePath;
-                                            QString scriptContent;
-                                            QStringList args;
-                                            QString process;
-#ifdef Q_OS_WIN
-                                            scriptFilePath = shadPath + "/extract_update.ps1";
-                                            scriptContent =
-                                                QString(
-                                                    "New-Item -ItemType Directory -Path \"%1\" "
-                                                    "-Force\n"
-                                                    "Expand-Archive -Path \"%2\" "
-                                                    "-DestinationPath \"%1\" -Force\n"
-                                                    "Remove-Item -Force \"%2\"\n" // delete ZIP
-                                                    "Remove-Item -Force \"%3\"\n" // delte script
-                                                    "cls\n")                      // clean console
-                                                    .arg(destFolder)
-                                                    .arg(zipPath)
-                                                    .arg(scriptFilePath);
-                                            process = "powershell.exe";
-                                            args << "-ExecutionPolicy" << "Bypass" << "-File"
-                                                 << scriptFilePath;
-
-#elif defined(Q_OS_LINUX) || defined(Q_OS_MAC)
-                                                scriptFilePath = shadPath + "/extract_update.sh";
-                                                scriptContent =
-                                                    QString("#!/bin/bash\n"
-                                                            "mkdir -p \"%1\"\n"
-                                                            "unzip -o \"%2\" -d \"%1\"\n"
-                                                            "rm \"%2\"\n" // delete ZIP
-                                                            "rm \"%3\"\n" // delte script
-                                                            "clear\n")    // clean console
-                                                        .arg(destFolder)
-                                                        .arg(zipPath)
-                                                        .arg(scriptFilePath);
-                                                process = "bash";
-                                                args << scriptFilePath;
-#endif
-                                            QFile scriptFile(scriptFilePath);
-                                            if (scriptFile.open(QIODevice::WriteOnly |
-                                                                QIODevice::Text)) {
-                                                QTextStream out(&scriptFile);
-#ifdef Q_OS_WIN
-                                                scriptFile.write("\xEF\xBB\xBF"); // BOM
-#endif
-                                                out << scriptContent;
-                                                scriptFile.close();
-#if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
-                                                scriptFile.setPermissions(QFile::ExeUser |
-                                                                          QFile::ReadUser |
-                                                                          QFile::WriteUser);
-#endif
-
-                                                QProcess::startDetached(process, args);
-
-                                                // wait 4 seconds while extracting before message
-                                                QTimer::singleShot(
-                                                    4000, this,
-                                                    [this, versionName, destFolder,
-                                                     progressDialog]() {
-                                                        progressDialog->close();
-                                                        progressDialog->deleteLater();
-
-                                                        QMessageBox::information(
-                                                            this, tr("Download"),
-                                                            tr("Version %1 has been downloaded")
-                                                                .arg(versionName));
-
-                                                        VersionDialog::LoadinstalledList();
-                                                    });
-
-                                            } else {
-                                                QMessageBox::warning(
-                                                    this, tr("Error"),
-                                                    tr("Failed to create zip extraction script:") +
-                                                        QString("\n%1").arg(scriptFilePath));
-                                            }
-                                        });
-
-                                    reply->deleteLater();
-                                });
-                        });
-                }
-            } else {
-                QMessageBox::warning(this, tr("Error"),
-                                     tr("Error accessing GitHub API") +
-                                         QString(":\n%1").arg(reply->errorString()));
-            }
-            reply->deleteLater();
-        });
-    });
-}
+    connect(ui->checkVersionDownloadButton, &QPushButton::clicked, this,
+            [this]() { DownloadListVersion(); });
+};
 
 VersionDialog::~VersionDialog() {
     delete ui;
 }
 
-void VersionDialog::LoadinstalledList() {
-    ui->installedTreeWidget->clear();
+void VersionDialog::DownloadListVersion() {
+    QNetworkAccessManager* manager = new QNetworkAccessManager(this);
+    QUrl url("https://api.github.com/repos/shadps4-emu/shadPS4/tags");
+    QNetworkRequest request(url);
+    QNetworkReply* reply = manager->get(request);
 
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() == QNetworkReply::NoError) {
+            QByteArray response = reply->readAll();
+            QJsonDocument doc = QJsonDocument::fromJson(response);
+            if (doc.isArray()) {
+                QJsonArray tags = doc.array();
+                ui->downloadTreeWidget->clear();
+
+                QTreeWidgetItem* preReleaseItem = nullptr;
+                QList<QTreeWidgetItem*> otherItems;
+                bool foundPreRelease = false;
+
+                //  > v.0.5.0
+                auto isVersionGreaterThan_0_5_0 = [](const QString& tagName) -> bool {
+                    QRegularExpression versionRegex(R"(v\.?(\d+)\.(\d+)\.(\d+))");
+                    QRegularExpressionMatch match = versionRegex.match(tagName);
+                    if (match.hasMatch()) {
+                        int major = match.captured(1).toInt();
+                        int minor = match.captured(2).toInt();
+                        int patch = match.captured(3).toInt();
+
+                        if (major > 0)
+                            return true;
+                        if (major == 0 && minor >= 5)
+                            return true;
+                        if (major == 0 && minor == 5 && patch > 0)
+                            return true;
+                    }
+                    return false;
+                };
+
+                for (const QJsonValue& value : tags) {
+                    QJsonObject tagObj = value.toObject();
+                    QString tagName = tagObj["name"].toString();
+
+                    if (tagName.startsWith("Pre-release", Qt::CaseInsensitive)) {
+                        if (!foundPreRelease) {
+                            preReleaseItem = new QTreeWidgetItem();
+                            preReleaseItem->setText(0, "Pre-release");
+                            foundPreRelease = true;
+                        }
+                        continue;
+                    }
+                    if (!isVersionGreaterThan_0_5_0(tagName)) {
+                        continue;
+                    }
+
+                    QTreeWidgetItem* item = new QTreeWidgetItem();
+                    item->setText(0, tagName);
+                    otherItems.append(item);
+                }
+
+                // If you didn't find Pre-release, add it manually
+                if (!foundPreRelease) {
+                    preReleaseItem = new QTreeWidgetItem();
+                    preReleaseItem->setText(0, "Pre-release");
+                }
+
+                // Add Pre-release first
+                if (preReleaseItem) {
+                    ui->downloadTreeWidget->addTopLevelItem(preReleaseItem);
+                }
+
+                // Add the others
+                for (QTreeWidgetItem* item : otherItems) {
+                    ui->downloadTreeWidget->addTopLevelItem(item);
+                }
+
+                // Assemble the current list
+                QStringList versionList;
+                for (int i = 0; i < ui->downloadTreeWidget->topLevelItemCount(); ++i) {
+                    QTreeWidgetItem* item = ui->downloadTreeWidget->topLevelItem(i);
+                    if (item)
+                        versionList.append(item->text(0));
+                }
+
+                QStringList cachedVersions = LoadDownloadCache();
+                if (cachedVersions == versionList) {
+                    QMessageBox::information(this, tr("Version list update"),
+                                             tr("No news, the version list is already updated."));
+                } else {
+                    SaveDownloadCache(versionList);
+                    QMessageBox::information(
+                        this, tr("Version list update"),
+                        tr("The latest versions have been added to the list for download."));
+                }
+
+                // selects a version in downloadTreeWidget calls the download stream
+                InstallSelectedVersion();
+            }
+        } else {
+            QMessageBox::warning(this, tr("Error"),
+                                 tr("Error accessing GitHub API") +
+                                     QString(":\n%1").arg(reply->errorString()));
+        }
+        reply->deleteLater();
+    });
+}
+
+void VersionDialog::InstallSelectedVersion() {
+    connect(
+        ui->downloadTreeWidget, &QTreeWidget::itemClicked, this,
+        [this](QTreeWidgetItem* item, int) {
+            if (m_gui_settings->GetValue(gui::gen_shadPath).toString() == "") {
+
+                QMessageBox::StandardButton reply;
+                reply = QMessageBox::warning(this, tr("Select the shadPS4 folder"),
+                                             // clang-format off
+tr("First you need to choose a location to save the versions in\n'Path to save versions'"));
+                // clang-format on
+                return;
+            }
+            QString versionName = item->text(0);
+            QString apiUrl;
+            QString platform;
+
+#ifdef Q_OS_WIN
+            platform = "win64-sdl";
+#elif defined(Q_OS_LINUX)
+            platform = "linux-sdl";
+#elif defined(Q_OS_MAC)
+            platform = "macos-sdl";
+#endif
+            if (versionName == "Pre-release") {
+                apiUrl = "https://api.github.com/repos/shadps4-emu/shadPS4/releases";
+            } else {
+                apiUrl = QString("https://api.github.com/repos/shadps4-emu/"
+                                 "shadPS4/releases/tags/%1")
+                             .arg(versionName);
+            }
+
+            { // Menssage yes/no
+                QMessageBox::StandardButton reply;
+                reply = QMessageBox::question(this, tr("Download"),
+                                              tr("Do you want to download the version:") +
+                                                  QString(" %1 ?").arg(versionName),
+                                              QMessageBox::Yes | QMessageBox::No);
+                if (reply == QMessageBox::No)
+                    return;
+            }
+
+            QNetworkAccessManager* manager = new QNetworkAccessManager(this);
+            QNetworkRequest request(apiUrl);
+            QNetworkReply* reply = manager->get(request);
+
+            connect(reply, &QNetworkReply::finished, this, [this, reply, platform, versionName]() {
+                if (reply->error() != QNetworkReply::NoError) {
+                    QMessageBox::warning(this, tr("Error"), reply->errorString());
+                    reply->deleteLater();
+                    return;
+                }
+
+                QByteArray response = reply->readAll();
+                QJsonDocument doc = QJsonDocument::fromJson(response);
+
+                QJsonArray assets;
+                QJsonObject release;
+
+                if (versionName == "Pre-release") {
+                    QJsonArray releases = doc.array();
+                    for (const QJsonValue& val : releases) {
+                        QJsonObject obj = val.toObject();
+                        if (obj["prerelease"].toBool()) {
+                            release = obj;
+                            assets = obj["assets"].toArray();
+                            break;
+                        }
+                    }
+                } else {
+                    release = doc.object();
+                    assets = release["assets"].toArray();
+                }
+
+                QString downloadUrl;
+                for (const QJsonValue& val : assets) {
+                    QJsonObject obj = val.toObject();
+                    QString name = obj["name"].toString();
+                    if (name.contains(platform)) {
+                        downloadUrl = obj["browser_download_url"].toString();
+                        break;
+                    }
+                }
+
+                if (downloadUrl.isEmpty()) {
+                    QMessageBox::warning(this, tr("Error"),
+                                         tr("No files available for this platform."));
+                    reply->deleteLater();
+                    return;
+                }
+
+                QString userPath = m_gui_settings->GetValue(gui::gen_shadPath).toString();
+                QString fileName = "temp_download_update.zip";
+                QString destinationPath = userPath + "/" + fileName;
+
+                QNetworkAccessManager* downloadManager = new QNetworkAccessManager(this);
+                QNetworkRequest downloadRequest(downloadUrl);
+                QNetworkReply* downloadReply = downloadManager->get(downloadRequest);
+
+                QDialog* progressDialog = new QDialog(this);
+                progressDialog->setWindowTitle(tr("Downloading %1").arg(versionName));
+                progressDialog->setFixedSize(400, 80);
+                QVBoxLayout* layout = new QVBoxLayout(progressDialog);
+                QProgressBar* progressBar = new QProgressBar(progressDialog);
+                progressBar->setRange(0, 100);
+                layout->addWidget(progressBar);
+                progressDialog->setLayout(layout);
+                progressDialog->show();
+
+                connect(downloadReply, &QNetworkReply::downloadProgress, this,
+                        [progressBar](qint64 bytesReceived, qint64 bytesTotal) {
+                            if (bytesTotal > 0)
+                                progressBar->setValue(
+                                    static_cast<int>((bytesReceived * 100) / bytesTotal));
+                        });
+
+                QFile* file = new QFile(destinationPath);
+                if (!file->open(QIODevice::WriteOnly)) {
+                    QMessageBox::warning(this, tr("Error"), tr("Could not save file."));
+                    file->deleteLater();
+                    downloadReply->deleteLater();
+                    return;
+                }
+
+                connect(downloadReply, &QNetworkReply::readyRead, this,
+                        [file, downloadReply]() { file->write(downloadReply->readAll()); });
+
+                connect(
+                    downloadReply, &QNetworkReply::finished, this,
+                    [this, file, downloadReply, progressDialog, release, userPath, versionName]() {
+                        file->flush();
+                        file->close();
+                        file->deleteLater();
+                        downloadReply->deleteLater();
+
+                        QString releaseName = release["name"].toString();
+
+                        // Remove "shadPS4 " from the beginning, if it exists
+                        if (releaseName.startsWith("shadps4 ", Qt::CaseInsensitive)) {
+                            releaseName = releaseName.mid(8);
+                        }
+
+                        // Remove "codename" if it exists
+                        releaseName.replace(QRegularExpression("\\b[Cc]odename\\s+"), "");
+
+                        QString folderName;
+                        if (versionName == "Pre-release") {
+                            folderName = release["tag_name"].toString();
+                        } else {
+                            QString datePart = release["published_at"].toString().left(10);
+                            folderName = QString("%1 - %2").arg(releaseName, datePart);
+                        }
+
+                        QString destFolder = QDir(userPath).filePath(folderName);
+
+                        // extract ZIP
+                        QString scriptFilePath;
+                        QString scriptContent;
+                        QStringList args;
+                        QString process;
+
+#ifdef Q_OS_WIN
+                        scriptFilePath = userPath + "/extract_update.ps1";
+                        scriptContent = QString("New-Item -ItemType Directory -Path \"%1\" "
+                                                "-Force\n"
+                                                "Expand-Archive -Path \"%2\" "
+                                                "-DestinationPath \"%1\" -Force\n"
+                                                "Remove-Item -Force \"%2\"\n"
+                                                "Remove-Item -Force \"%3\"\n"
+                                                "cls\n")
+                                            .arg(destFolder)
+                                            .arg(userPath + "/temp_download_update.zip")
+                                            .arg(scriptFilePath);
+                        process = "powershell.exe";
+                        args << "-ExecutionPolicy" << "Bypass" << "-File" << scriptFilePath;
+#elif defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+                    scriptFilePath = userPath + "/extract_update.sh";
+                    scriptContent = QString(
+                                        "#!/bin/bash\n"
+                                        "mkdir -p \"%1\"\n"
+                                        "unzip -o \"%2\" -d \"%1\"\n"
+                                        "rm \"%2\"\n"
+                                        "rm \"%3\"\n"
+                                        "clear\n")
+                                        .arg(destFolder)
+                                        .arg(userPath + "/temp_download_update.zip")
+                                        .arg(scriptFilePath);
+                    process = "bash";
+                    args << scriptFilePath;
+#endif
+
+                        QFile scriptFile(scriptFilePath);
+                        if (scriptFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                            QTextStream out(&scriptFile);
+#ifdef Q_OS_WIN
+                            scriptFile.write("\xEF\xBB\xBF"); // BOM
+#endif
+                            out << scriptContent;
+                            scriptFile.close();
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+                            scriptFile.setPermissions(QFile::ExeUser | QFile::ReadUser |
+                                                      QFile::WriteUser);
+#endif
+                            QProcess::startDetached(process, args);
+
+                            QTimer::singleShot(
+                                4000, this, [this, folderName, progressDialog, versionName]() {
+                                    progressDialog->close();
+                                    progressDialog->deleteLater();
+                                    QMessageBox::information(
+                                        this, tr("Download"),
+                                        tr("Version %1 has been downloaded").arg(versionName));
+                                    VersionDialog::LoadinstalledList();
+                                });
+
+                        } else {
+                            QMessageBox::warning(this, tr("Error"),
+                                                 tr("Failed to create zip extraction script:") +
+                                                     QString("\n%1").arg(scriptFilePath));
+                        }
+                    });
+                reply->deleteLater();
+            });
+        });
+}
+
+void VersionDialog::LoadinstalledList() {
     QString path = m_gui_settings->GetValue(gui::gen_shadPath).toString();
     QDir dir(path);
-    if (!dir.exists())
+    if (!dir.exists() || path.isEmpty())
         return;
 
+    ui->installedTreeWidget->clear();
+    ui->installedTreeWidget->setColumnCount(4);        // 4 = FullPath
+    ui->installedTreeWidget->setColumnHidden(3, true); // FullPath invisible
+
     QStringList folders = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
-    QRegularExpression versionRegex("^v\\.(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+    QRegularExpression versionRegex("^v(\\d+)\\.(\\d+)\\.(\\d+)$");
 
     QVector<QPair<QVector<int>, QString>> versionedDirs;
     QStringList otherDirs;
 
     for (const QString& folder : folders) {
-        QRegularExpressionMatch match = versionRegex.match(folder);
+        if (folder == "Pre-release") {
+            otherDirs.append(folder);
+            continue;
+        }
+
+        QRegularExpressionMatch match = versionRegex.match(folder.section(" - ", 0, 0));
         if (match.hasMatch()) {
-            QVector<int> versionParts;
-            for (int i = 1; i <= match.lastCapturedIndex(); ++i) {
-                versionParts.append(match.captured(i).toInt());
-            }
+            QVector<int> versionParts = {match.captured(1).toInt(), match.captured(2).toInt(),
+                                         match.captured(3).toInt()};
             versionedDirs.append({versionParts, folder});
         } else {
             otherDirs.append(folder);
@@ -487,16 +514,125 @@ void VersionDialog::LoadinstalledList() {
     }
 
     std::sort(otherDirs.begin(), otherDirs.end());
-    std::sort(versionedDirs.begin(), versionedDirs.end(),
-              [](const auto& a, const auto& b) { return a.first > b.first; });
 
+    std::sort(versionedDirs.begin(), versionedDirs.end(), [](const auto& a, const auto& b) {
+        if (a.first[0] != b.first[0])
+            return a.first[0] > b.first[0]; // major
+        if (a.first[1] != b.first[1])
+            return a.first[1] > b.first[1]; // minor
+        return a.first[2] > b.first[2];     // patch
+    });
+
+    // add (Pre-release, Test Build...)
     for (const QString& folder : otherDirs) {
         QTreeWidgetItem* item = new QTreeWidgetItem(ui->installedTreeWidget);
-        item->setText(0, folder);
+        QString fullPath = QDir(path).filePath(folder);
+        item->setText(3, fullPath); // FullPath invisible column
+
+        if (folder.startsWith("Pre-release-shadPS4")) {
+            QStringList parts = folder.split('-');
+            item->setText(0, "Pre-release"); // Version
+            QString shortHash;
+            if (parts.size() >= 7) {
+                shortHash = parts[6].left(7);
+            } else {
+                shortHash = "";
+            }
+            item->setText(1, shortHash);
+            if (parts.size() >= 6) {
+                QString date = QString("%1-%2-%3").arg(parts[3], parts[4], parts[5]);
+                item->setText(2, date);
+            } else {
+                item->setText(2, "");
+            }
+        } else if (folder.contains(" - ")) {
+            QStringList parts = folder.split(" - ");
+            item->setText(0, parts.value(0));
+            item->setText(1, parts.value(1));
+            item->setText(2, parts.value(2));
+        } else {
+            item->setText(0, folder); // only Version
+            item->setText(1, "");
+            item->setText(2, "");
+        }
     }
 
+    // add versions
     for (const auto& pair : versionedDirs) {
         QTreeWidgetItem* item = new QTreeWidgetItem(ui->installedTreeWidget);
-        item->setText(0, pair.second);
+        QString fullPath = QDir(path).filePath(pair.second);
+        item->setText(3, fullPath); // FullPath invisible column
+
+        if (pair.second.contains(" - ")) {
+            QStringList parts = pair.second.split(" - ");
+            item->setText(0, parts.value(0)); // Version
+            item->setText(1, parts.value(1)); // Name
+            item->setText(2, parts.value(2)); // Date
+        } else {
+            item->setText(0, pair.second); // only Version
+            item->setText(1, "");
+            item->setText(2, "");
+        }
     }
+
+    ui->installedTreeWidget->resizeColumnToContents(1); // 1 = Name
+    ui->installedTreeWidget->setColumnWidth(1, ui->installedTreeWidget->columnWidth(1) + 50);
+}
+
+QStringList VersionDialog::LoadDownloadCache() {
+    QString cachePath =
+        QDir(m_gui_settings->GetValue(gui::gen_shadPath).toString()).filePath("cache.version");
+    QStringList cachedVersions;
+    QFile file(cachePath);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&file);
+        while (!in.atEnd())
+            cachedVersions.append(in.readLine().trimmed());
+    }
+    return cachedVersions;
+}
+
+void VersionDialog::SaveDownloadCache(const QStringList& versions) {
+    QString cachePath =
+        QDir(m_gui_settings->GetValue(gui::gen_shadPath).toString()).filePath("cache.version");
+    QFile file(cachePath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream out(&file);
+        for (const QString& v : versions)
+            out << v << "\n";
+    }
+}
+
+void VersionDialog::PopulateDownloadTree(const QStringList& versions) {
+    ui->downloadTreeWidget->clear();
+
+    QTreeWidgetItem* preReleaseItem = nullptr;
+    QList<QTreeWidgetItem*> otherItems;
+    bool foundPreRelease = false;
+
+    for (const QString& tagName : versions) {
+        if (tagName.startsWith("Pre-release", Qt::CaseInsensitive)) {
+            if (!foundPreRelease) {
+                preReleaseItem = new QTreeWidgetItem();
+                preReleaseItem->setText(0, "Pre-release");
+                foundPreRelease = true;
+            }
+            continue;
+        }
+        QTreeWidgetItem* item = new QTreeWidgetItem();
+        item->setText(0, tagName);
+        otherItems.append(item);
+    }
+
+    if (!foundPreRelease) {
+        preReleaseItem = new QTreeWidgetItem();
+        preReleaseItem->setText(0, "Pre-release");
+    }
+
+    if (preReleaseItem)
+        ui->downloadTreeWidget->addTopLevelItem(preReleaseItem);
+    for (QTreeWidgetItem* item : otherItems)
+        ui->downloadTreeWidget->addTopLevelItem(item);
+
+    InstallSelectedVersion();
 }

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -29,14 +29,13 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
     : QDialog(parent), ui(new Ui::VersionDialog), m_gui_settings(std::move(gui_settings)) {
     ui->setupUi(this);
 
-    ui->checkOnStartupPreCheckBox->setChecked(
+    ui->checkOnStartupCheckBox->setChecked(
         m_gui_settings->GetValue(gui::vm_checkOnStartup).toBool());
-    ui->updatePreCheckBox->setChecked(m_gui_settings->GetValue(gui::vm_showChangeLog).toBool());
+    ui->showChangelogCheckBox->setChecked(m_gui_settings->GetValue(gui::vm_showChangeLog).toBool());
 
-    connect(ui->checkOnStartupPreCheckBox, &QCheckBox::toggled, this,
+    connect(ui->checkOnStartupCheckBox, &QCheckBox::toggled, this,
             [this](bool checked) { m_gui_settings->SetValue(gui::vm_checkOnStartup, checked); });
-
-    connect(ui->updatePreCheckBox, &QCheckBox::toggled, this,
+    connect(ui->showChangelogCheckBox, &QCheckBox::toggled, this,
             [this](bool checked) { m_gui_settings->SetValue(gui::vm_showChangeLog, checked); });
 
     networkManager = new QNetworkAccessManager(this);
@@ -750,7 +749,7 @@ void VersionDialog::checkUpdatePre(const bool showMessage) {
                 QJsonDocument doc = QJsonDocument::fromJson(resp);
                 if (!doc.isArray()) {
                     QMessageBox::warning(this, tr("Error"),
-                                         "The GitHub API response is not a valid JSON array.");
+                                         tr("The GitHub API response is not a valid JSON array."));
                     reply->deleteLater();
                     return;
                 }

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QTreeWidget>
 
 #include "gui_settings.h"
 
@@ -17,6 +18,7 @@ class VersionDialog : public QDialog {
 public:
     explicit VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
     ~VersionDialog();
+    void onItemChanged(QTreeWidgetItem* item, int column);
     void DownloadListVersion();
     void InstallSelectedVersion();
 

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QDialog>
+
+#include "gui_settings.h"
+
+namespace Ui {
+class VersionDialog;
+}
+
+class VersionDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
+    ~VersionDialog();
+
+private:
+    Ui::VersionDialog* ui;
+    std::shared_ptr<gui_settings> m_gui_settings;
+
+    void LoadinstalledList();
+};

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -17,10 +17,15 @@ class VersionDialog : public QDialog {
 public:
     explicit VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
     ~VersionDialog();
+    void DownloadListVersion();
+    void InstallSelectedVersion();
 
 private:
     Ui::VersionDialog* ui;
     std::shared_ptr<gui_settings> m_gui_settings;
 
     void LoadinstalledList();
+    QStringList LoadDownloadCache();
+    void SaveDownloadCache(const QStringList& versions);
+    void PopulateDownloadTree(const QStringList& versions);
 };

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QTextBrowser>
 #include <QTreeWidget>
 
 #include "gui_settings.h"
@@ -19,15 +20,23 @@ public:
     explicit VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
     ~VersionDialog();
     void onItemChanged(QTreeWidgetItem* item, int column);
+    void checkUpdatePre(const bool showMessage);
     void DownloadListVersion();
     void InstallSelectedVersion();
 
 private:
     Ui::VersionDialog* ui;
     std::shared_ptr<gui_settings> m_gui_settings;
+    QNetworkAccessManager* networkManager;
 
     void LoadinstalledList();
     QStringList LoadDownloadCache();
     void SaveDownloadCache(const QStringList& versions);
     void PopulateDownloadTree(const QStringList& versions);
+    void showPreReleaseUpdateDialog(const QString& localHash, const QString& latestHash,
+                                    const QString& latestTag);
+    void requestChangelog(const QString& localHash, const QString& latestHash,
+                          const QString& latestTag, QTextBrowser* outputView);
+    void installPreReleaseByTag(const QString& tagName);
+    void showDownloadDialog(const QString& tagName, const QString& downloadUrl);
 };

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -48,6 +48,49 @@
     </property>
     <layout class="QVBoxLayout" name="versionTabLayout">
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_11">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="shadps4GroupBox">
+         <property name="title">
+          <string>Path to save versions</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_shadps4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_shadps4" stretch="0,0">
+            <item>
+             <widget class="QLineEdit" name="currentShadPath">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="placeholderText">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="browse_shad_path">
+              <property name="text">
+               <string>Browse</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_8">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -67,7 +110,6 @@
           <widget class="QLabel" name="label">
            <property name="font">
             <font>
-             <pointsize>11</pointsize>
              <bold>false</bold>
             </font>
            </property>
@@ -80,12 +122,12 @@
           <widget class="QTreeWidget" name="installedTreeWidget">
            <column>
             <property name="text">
-             <string>Name</string>
+             <string>Version</string>
             </property>
            </column>
            <column>
             <property name="text">
-             <string>Version</string>
+             <string>Name</string>
             </property>
            </column>
            <column>
@@ -142,12 +184,25 @@
           </layout>
          </item>
          <item>
+          <widget class="QPushButton" name="checkVersionDownloadButton">
+           <property name="text">
+            <string>Check Versions</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QTreeWidget" name="downloadTreeWidget">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
            </property>
            <column>
             <property name="text">
@@ -162,82 +217,32 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="checkVersionDownloadButton">
-           <property name="text">
-            <string>Check Versions</string>
+          <layout class="QVBoxLayout" name="verticalLayout_11">
+           <property name="topMargin">
+            <number>0</number>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_11">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="shadps4GroupBox">
-         <property name="title">
-          <string>Path to save versions</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_shadps4">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_shadps4" stretch="0,0">
-            <item>
-             <widget class="QLineEdit" name="currentShadPath">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-              <property name="placeholderText">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="browse_shad_path">
-              <property name="text">
-               <string>Browse</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_11">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="updatePreCheckBox">
-           <property name="text">
-            <string>Check for pre-release updates at startup</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkCompatibilityOnStartupPreCheckBox">
-           <property name="text">
-            <string>Always show pre-release changelog</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="updateCompatibilityPreButton">
-           <property name="text">
-            <string>Check for pre-release Updates</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="updatePreCheckBox">
+             <property name="text">
+              <string>Check for pre-release updates at startup</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="checkCompatibilityOnStartupPreCheckBox">
+             <property name="text">
+              <string>Always show pre-release changelog</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="updateCompatibilityPreButton">
+             <property name="text">
+              <string>Check for pre-release Updates</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -48,18 +48,18 @@
     </property>
     <layout class="QVBoxLayout" name="versionTabLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <layout class="QHBoxLayout" name="horizontalLayout_path">
        <property name="topMargin">
         <number>0</number>
        </property>
        <item>
-        <widget class="QGroupBox" name="shadps4GroupBox">
+        <widget class="QGroupBox" name="patchGroupBox">
          <property name="title">
           <string>Path to save versions</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_shadps4">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_shadps4" stretch="0,0">
+           <layout class="QHBoxLayout" name="horizontalLayout_patch" stretch="0,0">
             <item>
              <widget class="QLineEdit" name="currentVersionPath">
               <property name="sizePolicy">
@@ -91,9 +91,9 @@
       </layout>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <layout class="QHBoxLayout" name="horizontalLayout_installed_download">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <layout class="QVBoxLayout" name="verticalLayout_installed">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -107,7 +107,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="label_installed">
            <property name="font">
             <font>
              <bold>false</bold>
@@ -143,7 +143,7 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_14">
+          <layout class="QHBoxLayout" name="horizontalLayout_button_installed">
            <property name="topMargin">
             <number>0</number>
            </property>
@@ -173,20 +173,13 @@
         </layout>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_10">
+        <layout class="QVBoxLayout" name="verticalLayout_download">
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_13">
-           <property name="topMargin">
-            <number>0</number>
+          <widget class="QLabel" name="label_download">
+           <property name="text">
+            <string>Download</string>
            </property>
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Download</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="checkVersionDownloadButton">
@@ -222,19 +215,19 @@
           </widget>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_11">
+          <layout class="QVBoxLayout" name="verticalLayout_check_update">
            <property name="topMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QCheckBox" name="updatePreCheckBox">
+            <widget class="QCheckBox" name="checkOnStartupCheckBox">
              <property name="text">
               <string>Check for Pre-release updates at startup</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="checkOnStartupPreCheckBox">
+            <widget class="QCheckBox" name="showChangelogCheckBox">
              <property name="text">
               <string>Always show Pre-release changelog</string>
              </property>

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+     SPDX-License-Identifier: GPL-2.0-or-later -->
+<ui version="4.0">
+ <class>VersionDialog</class>
+ <widget class="QDialog" name="VersionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>780</width>
+    <height>511</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Version Manager</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>:/images/shadps4.ico</normaloff>:/images/shadps4.ico</iconset>
+  </property>
+  <widget class="QScrollArea" name="versionTab">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>781</width>
+     <height>511</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="widgetResizable">
+    <bool>true</bool>
+   </property>
+   <widget class="QWidget" name="versionTabContents">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>779</width>
+      <height>509</height>
+     </rect>
+    </property>
+    <layout class="QVBoxLayout" name="versionTabLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="font">
+            <font>
+             <pointsize>11</pointsize>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Installed</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTreeWidget" name="installedTreeWidget">
+           <column>
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Version</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Date</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_14">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QPushButton" name="addCustomVersionButton">
+             <property name="text">
+              <string>Add Custom</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="checkChangesVersionButton">
+             <property name="text">
+              <string>Check Changes (Refresh)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="deleteVersionButton">
+             <property name="text">
+              <string>Delete</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_10">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_13">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Download</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QTreeWidget" name="downloadTreeWidget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <column>
+            <property name="text">
+             <string>Version</string>
+            </property>
+           </column>
+           <item>
+            <property name="text">
+             <string/>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="checkVersionDownloadButton">
+           <property name="text">
+            <string>Check Versions</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_11">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="shadps4GroupBox">
+         <property name="title">
+          <string>Path to save versions</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_shadps4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_shadps4" stretch="0,0">
+            <item>
+             <widget class="QLineEdit" name="currentShadPath">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="placeholderText">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="browse_shad_path">
+              <property name="text">
+               <string>Browse</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_11">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="updatePreCheckBox">
+           <property name="text">
+            <string>Check for pre-release updates at startup</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkCompatibilityOnStartupPreCheckBox">
+           <property name="text">
+            <string>Always show pre-release changelog</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="updateCompatibilityPreButton">
+           <property name="text">
+            <string>Check for pre-release Updates</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -8,8 +8,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>780</width>
-    <height>511</height>
+    <width>700</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,8 +24,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>781</width>
-     <height>511</height>
+     <width>700</width>
+     <height>500</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -42,8 +42,8 @@
      <rect>
       <x>0</x>
       <y>0</y>
-      <width>779</width>
-      <height>509</height>
+      <width>698</width>
+      <height>498</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="versionTabLayout">
@@ -61,7 +61,7 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_shadps4" stretch="0,0">
             <item>
-             <widget class="QLineEdit" name="currentShadPath">
+             <widget class="QLineEdit" name="currentVersionPath">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -77,7 +77,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="browse_shad_path">
+             <widget class="QPushButton" name="browse_versionPath">
               <property name="text">
                <string>Browse</string>
               </property>
@@ -122,12 +122,17 @@
           <widget class="QTreeWidget" name="installedTreeWidget">
            <column>
             <property name="text">
+             <string>Selected</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
              <string>Version</string>
             </property>
            </column>
            <column>
             <property name="text">
-             <string>Name</string>
+             <string>Codename</string>
             </property>
            </column>
            <column>
@@ -150,16 +155,16 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="checkChangesVersionButton">
+            <widget class="QPushButton" name="deleteVersionButton">
              <property name="text">
-              <string>Check Changes (Refresh)</string>
+              <string>Delete</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="deleteVersionButton">
+            <widget class="QPushButton" name="checkChangesVersionButton">
              <property name="text">
-              <string>Delete</string>
+              <string>Refresh List</string>
              </property>
             </widget>
            </item>
@@ -186,7 +191,7 @@
          <item>
           <widget class="QPushButton" name="checkVersionDownloadButton">
            <property name="text">
-            <string>Check Versions</string>
+            <string>Refresh List</string>
            </property>
           </widget>
          </item>

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -229,21 +229,21 @@
            <item>
             <widget class="QCheckBox" name="updatePreCheckBox">
              <property name="text">
-              <string>Check for pre-release updates at startup</string>
+              <string>Check for Pre-release updates at startup</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="checkCompatibilityOnStartupPreCheckBox">
+            <widget class="QCheckBox" name="checkOnStartupPreCheckBox">
              <property name="text">
-              <string>Always show pre-release changelog</string>
+              <string>Always show Pre-release changelog</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="updateCompatibilityPreButton">
+            <widget class="QPushButton" name="updatePreButton">
              <property name="text">
-              <string>Check for pre-release Updates</string>
+              <string>Check for Pre-release Updates</string>
              </property>
             </widget>
            </item>

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+<!-- SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
      SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>VersionDialog</class>


### PR DESCRIPTION
QtLaucher is just the interface, so now it is necessary to download the emulator separately, this new screen allows you to download and choose which version to use within the emulator itself

<img width="702" height="532" alt="image" src="https://github.com/user-attachments/assets/58ca45c6-fb4e-463b-b785-afd5741d8674" />

It is possible to select the version in the main menu after downloading
<img width="269" height="230" alt="image" src="https://github.com/user-attachments/assets/f28a654b-c466-430c-ad0a-baa45602635a" />

Add custom: creates a copy of a version you select on your computer and adds it to the list with a custom name
<img width="329" height="221" alt="image" src="https://github.com/user-attachments/assets/3e48a453-ada4-405e-8111-f20d43bb672f" />

The first time you open the emulator, you can also choose which folder these emulator versions will be saved in.
<img width="525" height="276" alt="image" src="https://github.com/user-attachments/assets/e2b49df9-cc6d-4371-a0f0-a3e9a9b1bceb" />


*There will be 2 automatic update options, the normal one already known in Settings that updates the QT interface, and this one on this screen where it only updates the emulator in the pre-release version
