### PR TITLE
Move vblank to experimental tab, add additional dmem setting to game-specific GUI

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -114,6 +114,8 @@ bool isNeoModeConsole();
 void setNeoMode(bool enable, bool is_game_specific = false);
 bool isDevKitConsole();
 void setDevKitConsole(bool enable, bool is_game_specific = false);
+int getExtraDmemInMbytes();
+void setExtraDmemInMbytes(int value, bool is_game_specific = false);
 
 bool vkValidationGpuEnabled(); // no set
 bool getIsMotionControlsEnabled();

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>8</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -77,7 +77,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -1034,7 +1034,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1248,49 +1248,6 @@
                    </layout>
                   </widget>
                  </item>
-                 <item>
-                  <widget class="QGroupBox" name="heightDivider">
-                   <property name="title">
-                    <string>Vblank Frequency</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="vblankLayout">
-                    <item>
-                     <widget class="QSpinBox" name="vblankSpinBox">
-                      <property name="frame">
-                       <bool>true</bool>
-                      </property>
-                      <property name="alignment">
-                       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                      </property>
-                      <property name="specialValueText">
-                       <string/>
-                      </property>
-                      <property name="accelerated">
-                       <bool>true</bool>
-                      </property>
-                      <property name="correctionMode">
-                       <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                      </property>
-                      <property name="keyboardTracking">
-                       <bool>false</bool>
-                      </property>
-                      <property name="suffix">
-                       <string notr="true">Hz</string>
-                      </property>
-                      <property name="minimum">
-                       <number>60</number>
-                      </property>
-                      <property name="maximum">
-                       <number>9999</number>
-                      </property>
-                      <property name="value">
-                       <number>60</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>
@@ -1441,7 +1398,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1656,7 +1613,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>501</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0">
@@ -1941,8 +1898,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>536</height>
+         <width>932</width>
+         <height>503</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -2144,7 +2101,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>299</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2465,7 +2422,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>287</height>
+         <height>395</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2558,6 +2515,100 @@
               </layout>
              </widget>
             </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_10">
+              <item>
+               <widget class="QGroupBox" name="dmemGroupBox">
+                <property name="title">
+                 <string>Additional DMem Allocation</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_4">
+                 <item>
+                  <widget class="QSpinBox" name="dmemSpinBox">
+                   <property name="frame">
+                    <bool>true</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                   </property>
+                   <property name="specialValueText">
+                    <string/>
+                   </property>
+                   <property name="accelerated">
+                    <bool>true</bool>
+                   </property>
+                   <property name="correctionMode">
+                    <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                   </property>
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="suffix">
+                    <string notr="true">MB</string>
+                   </property>
+                   <property name="minimum">
+                    <number>0</number>
+                   </property>
+                   <property name="maximum">
+                    <number>100000</number>
+                   </property>
+                   <property name="value">
+                    <number>0</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="heightDivider">
+                <property name="title">
+                 <string>Vblank Frequency</string>
+                </property>
+                <layout class="QVBoxLayout" name="vblankLayout">
+                 <item>
+                  <widget class="QSpinBox" name="vblankSpinBox">
+                   <property name="frame">
+                    <bool>true</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                   </property>
+                   <property name="specialValueText">
+                    <string/>
+                   </property>
+                   <property name="accelerated">
+                    <bool>true</bool>
+                   </property>
+                   <property name="correctionMode">
+                    <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                   </property>
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="suffix">
+                    <string notr="true">Hz</string>
+                   </property>
+                   <property name="minimum">
+                    <number>60</number>
+                   </property>
+                   <property name="maximum">
+                    <number>9999</number>
+                   </property>
+                   <property name="value">
+                    <number>60</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
             <item>
              <widget class="QLabel" name="ExperimentalLabel">
               <property name="sizeIncrement">


### PR DESCRIPTION
Sticking with the general idea of having all game-specific settings in the same tab, and to better communicate that changing vblank can lead to unexpected behavior, moved the vblank setting to the experimental tab.

Also added the additional dmem setting (https://github.com/shadps4-emu/shadPS4/pull/3513) to the game-specific GUI

<img width="970" height="792" alt="image" src="https://github.com/user-attachments/assets/10b47076-938c-4518-9bd5-8b22afcc8aaf" />
