### PR TITLE
cheats support

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -214,9 +214,18 @@ static string trophyKey = "";
 // Config version, used to determine if a user's config file is outdated.
 static string config_version = Common::g_scm_rev;
 
-// These two entries aren't stored in the config
+// These entries aren't stored in the config
 static bool overrideControllerColor = false;
 static int controllerCustomColorRGB[3] = {0, 0, 255};
+static bool isGameRunning = false;
+
+bool getGameRunning() {
+    return isGameRunning;
+}
+
+void setGameRunning(bool running) {
+    isGameRunning = running;
+}
 
 std::filesystem::path getSysModulesPath() {
     if (sys_modules_path.empty()) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -27,6 +27,8 @@ void load(const std::filesystem::path& path, bool is_game_specific = false);
 void save(const std::filesystem::path& path, bool is_game_specific = false);
 void resetGameSpecificValue(std::string entry);
 
+bool getGameRunning();
+void setGameRunning(bool running);
 int getVolumeSlider();
 void setVolumeSlider(int volumeValue, bool is_game_specific = false);
 std::string getTrophyKey();

--- a/src/ipc/ipc_client.h
+++ b/src/ipc/ipc_client.h
@@ -24,7 +24,9 @@ public:
     void toggleFullscreen();
     void sendMemoryPatches(std::string modNameStr, std::string offsetStr, std::string valueStr,
                            std::string targetStr, std::string sizeStr, bool isOffset,
-                           bool littleEndian, MemoryPatcher::PatchMask patchMask, int maskOffset);
+                           bool littleEndian,
+                           MemoryPatcher::PatchMask patchMask = MemoryPatcher::PatchMask::None,
+                           int maskOffset = 0);
     std::function<void()> gameClosedFunc;
     std::function<void()> startGameFunc;
     std::function<void()> restartEmulatorFunc;

--- a/src/qt_gui/cheats_patches.h
+++ b/src/qt_gui/cheats_patches.h
@@ -25,14 +25,15 @@
 #include <QVector>
 #include <QWidget>
 #include "gui_settings.h"
+#include "ipc/ipc_client.h"
 
 class CheatsPatches : public QWidget {
     Q_OBJECT
 
 public:
-    CheatsPatches(std::shared_ptr<gui_settings> gui_settings, const QString& gameName,
-                  const QString& gameSerial, const QString& gameVersion, const QString& gameSize,
-                  const QPixmap& gameImage, QWidget* parent = nullptr);
+    CheatsPatches(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<IpcClient> ipc_client,
+                  const QString& gameName, const QString& gameSerial, const QString& gameVersion,
+                  const QString& gameSize, const QPixmap& gameImage, QWidget* parent = nullptr);
     ~CheatsPatches();
 
     void downloadCheats(const QString& source, const QString& m_gameSerial,
@@ -102,6 +103,7 @@ private:
     QMap<QString, PatchInfo> m_patchInfos;
     QVector<QCheckBox*> m_cheatCheckBoxes;
     std::shared_ptr<gui_settings> m_gui_settings;
+    std::shared_ptr<IpcClient> m_ipc_client;
 
     // UI Elements
     QVBoxLayout* rightLayout;

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -9,9 +9,9 @@
 GameGridFrame::GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
                              std::shared_ptr<GameInfoClass> game_info_get,
                              std::shared_ptr<CompatibilityInfoClass> compat_info_get,
-                             QWidget* parent)
+                             std::shared_ptr<IpcClient> ipc_client, QWidget* parent)
     : QTableWidget(parent), m_gui_settings(std::move(gui_settings)), m_game_info(game_info_get),
-      m_compat_info(compat_info_get) {
+      m_compat_info(compat_info_get), m_ipc_client(ipc_client) {
     icon_size = m_gui_settings->GetValue(gui::gg_icon_size).toInt();
     windowWidth = parent->width();
     this->setShowGrid(false);
@@ -36,7 +36,7 @@ GameGridFrame::GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
             &GameGridFrame::RefreshGridBackgroundImage);
     connect(this, &QTableWidget::customContextMenuRequested, this, [=, this](const QPoint& pos) {
         int changedFavorite = m_gui_context_menus.RequestGameMenu(
-            pos, m_game_info->m_games, m_compat_info, m_gui_settings, this, true,
+            pos, m_game_info->m_games, m_compat_info, m_gui_settings, m_ipc_client, this, true,
             [mw = QPointer<MainWindow>(qobject_cast<MainWindow*>(this->window()))](
                 const QStringList& args) {
                 if (mw)

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -36,7 +36,7 @@ GameGridFrame::GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
             &GameGridFrame::RefreshGridBackgroundImage);
     connect(this, &QTableWidget::customContextMenuRequested, this, [=, this](const QPoint& pos) {
         int changedFavorite = m_gui_context_menus.RequestGameMenu(
-            pos, m_game_info->m_games, m_compat_info, m_gui_settings, m_ipc_client, this, true,
+            pos, m_game_info->m_games, m_compat_info, m_gui_settings, m_ipc_client, this, false,
             [mw = QPointer<MainWindow>(qobject_cast<MainWindow*>(this->window()))](
                 const QStringList& args) {
                 if (mw)

--- a/src/qt_gui/game_grid_frame.h
+++ b/src/qt_gui/game_grid_frame.h
@@ -39,6 +39,7 @@ private:
     int m_last_opacity = -1; // Track last opacity to avoid unnecessary recomputation
     std::filesystem::path m_current_game_path; // Track current game path to detect changes
     std::shared_ptr<gui_settings> m_gui_settings;
+    std::shared_ptr<IpcClient> m_ipc_client;
     void SetFavoriteIcon(QWidget* parentWidget, QVector<GameInfo> m_games_, int gameCounter);
     void SetGameConfigIcon(QWidget* parentWidget, QVector<GameInfo> m_games_, int gameCounter);
     bool CompareWithFavorite(GameInfo a, GameInfo b);
@@ -47,7 +48,7 @@ public:
     explicit GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
                            std::shared_ptr<GameInfoClass> game_info_get,
                            std::shared_ptr<CompatibilityInfoClass> compat_info_get,
-                           QWidget* parent = nullptr);
+                           std::shared_ptr<IpcClient> ipc_client, QWidget* parent = nullptr);
     void PopulateGameGrid(QVector<GameInfo> m_games, bool fromSearch);
     bool IsValidCellSelected();
     void SortByFavorite(QVector<GameInfo>* game_list);

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -12,9 +12,10 @@
 GameListFrame::GameListFrame(std::shared_ptr<gui_settings> gui_settings,
                              std::shared_ptr<GameInfoClass> game_info_get,
                              std::shared_ptr<CompatibilityInfoClass> compat_info_get,
-                             QWidget* parent)
+                             std::shared_ptr<IpcClient> ipc_client, QWidget* parent)
     : QTableWidget(parent), m_gui_settings(std::move(gui_settings)), m_game_info(game_info_get),
-      m_compat_info(compat_info_get) {
+      m_compat_info(compat_info_get), m_ipc_client(ipc_client) {
+
     icon_size = m_gui_settings->GetValue(gui::gl_icon_size).toInt();
     last_favorite = "";
     this->setShowGrid(false);
@@ -82,7 +83,7 @@ GameListFrame::GameListFrame(std::shared_ptr<gui_settings> gui_settings,
 
     connect(this, &QTableWidget::customContextMenuRequested, this, [=, this](const QPoint& pos) {
         int changedFavorite = m_gui_context_menus.RequestGameMenu(
-            pos, m_game_info->m_games, m_compat_info, m_gui_settings, this, true,
+            pos, m_game_info->m_games, m_compat_info, m_gui_settings, m_ipc_client, this, true,
             [mw = QPointer<MainWindow>(qobject_cast<MainWindow*>(this->window()))](
                 const QStringList& args) {
                 if (mw)

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -18,6 +18,7 @@
 #include "game_list_utils.h"
 #include "gui_context_menus.h"
 #include "gui_settings.h"
+#include "ipc/ipc_client.h"
 
 class GameListFrame : public QTableWidget {
     Q_OBJECT
@@ -25,7 +26,7 @@ public:
     explicit GameListFrame(std::shared_ptr<gui_settings> gui_settings,
                            std::shared_ptr<GameInfoClass> game_info_get,
                            std::shared_ptr<CompatibilityInfoClass> compat_info_get,
-                           QWidget* parent = nullptr);
+                           std::shared_ptr<IpcClient> ipc_client, QWidget* parent = nullptr);
 Q_SIGNALS:
     void GameListFrameClosed();
 
@@ -64,6 +65,7 @@ public:
     GuiContextMenus m_gui_context_menus;
     std::shared_ptr<GameInfoClass> m_game_info;
     std::shared_ptr<CompatibilityInfoClass> m_compat_info;
+    std::shared_ptr<IpcClient> m_ipc_client;
 
     int icon_size;
     std::string last_favorite;

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -19,6 +19,7 @@
 #include "compatibility_info.h"
 #include "game_info.h"
 #include "gui_settings.h"
+#include "ipc/ipc_client.h"
 #include "settings_dialog.h"
 #include "trophy_viewer.h"
 
@@ -36,8 +37,10 @@ class GuiContextMenus : public QObject {
 public:
     int RequestGameMenu(const QPoint& pos, QVector<GameInfo>& m_games,
                         std::shared_ptr<CompatibilityInfoClass> m_compat_info,
-                        std::shared_ptr<gui_settings> settings, QTableWidget* widget, bool isList,
+                        std::shared_ptr<gui_settings> settings,
+                        std::shared_ptr<IpcClient> m_ipc_client, QTableWidget* widget, bool isList,
                         std::function<void(QStringList)> launch_func) {
+
         QPoint global_pos = widget->viewport()->mapToGlobal(pos);
         std::shared_ptr<gui_settings> m_gui_settings = std::move(settings);
         int itemID = 0;
@@ -377,8 +380,9 @@ public:
             QString iconPath;
             Common::FS::PathToQString(iconPath, m_games[itemID].icon_path);
             QPixmap gameImage(iconPath);
-            CheatsPatches* cheatsPatches = new CheatsPatches(m_gui_settings, gameName, gameSerial,
-                                                             gameVersion, gameSize, gameImage);
+            CheatsPatches* cheatsPatches =
+                new CheatsPatches(m_gui_settings, m_ipc_client, gameName, gameSerial, gameVersion,
+                                  gameSize, gameImage);
             cheatsPatches->show();
             connect(widget->parent(), &QWidget::destroyed, cheatsPatches,
                     [cheatsPatches]() { cheatsPatches->deleteLater(); });

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -82,7 +82,6 @@ private:
 
     bool isIconBlack = false;
     bool isTableList = true;
-    bool isGameRunning = false;
     bool isWhite = false;
     bool is_paused = false;
     std::string runningGameSerial = "";


### PR DESCRIPTION
Implements cheats in qtlauncher with IPC.

Moves the isGameRunning variable to config because the cheats dialog needs to know real-time whether the game is running, so passing the variable through the game list / game grid constructors (which is usually only called on application startup) and then to the cheats class constructor won't work.