### PR TITLE
Minor interface and translation fixes

### DIFF
--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -136,15 +136,25 @@ static auto UserPaths = [] {
     std::ofstream notice_file(user_dir / CUSTOM_TROPHY / "Notice.txt");
     if (notice_file.is_open()) {
         notice_file
-            << "++++++++++++++++++++++++++++++++\n+ Custom Trophy Images / Sound "
-               "+\n++++++++++++++++++++++++++++++++\n\nYou can add custom images to the "
-               "trophies.\n*We recommend a square resolution image, for example 200x200, 500x500, "
-               "the same size as the height and width.\nIn this folder ('user\\custom_trophy'), "
-               "add the files with the following "
-               "names:\n\nbronze.png\nsilver.png\ngold.png\nplatinum.png\n\nYou can add a custom "
-               "sound for trophy notifications.\n*By default, no audio is played unless it is in "
-               "this folder and you are using the QT version.\nIn this folder "
-               "('user\\custom_trophy'), add the files with the following names:\n\ntrophy.mp3";
+            // clang-format off
+<< "++++++++++++++++++++++++++++++++\n"
+"+ Custom Trophy Images / Sound +\n"
+"++++++++++++++++++++++++++++++++\n\n"
+
+"You can add custom images to the trophies.\n"
+"*We recommend a square resolution image, for example 200x200, 500x500, the same size as the height and width.\n"
+"In this folder ('user\\custom_trophy'), add the files with the following names:\n\n"
+"bronze.png\n"
+"silver.png\n"
+"gold.png\n"
+"platinum.png\n\n"
+
+"You can add a custom sound for trophy notifications.\n"
+"*By default, no audio is played unless it is in this folder and you are using the QT version.\n"
+"In this folder ('user\\custom_trophy'), add the files with the following names:\n\n"
+
+"trophy.wav OR trophy.mp3";
+        // clang-format on
         notice_file.close();
     }
 

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -32,7 +32,7 @@ CheckUpdate::CheckUpdate(std::shared_ptr<gui_settings> gui_settings, const bool 
                          QWidget* parent)
     : QDialog(parent), m_gui_settings(std::move(gui_settings)),
       networkManager(new QNetworkAccessManager(this)) {
-    setWindowTitle(tr("Auto Updater - User Interface"));
+    setWindowTitle(tr("Auto Updater - GUI"));
     setFixedSize(0, 0);
     CheckForUpdates(showMessage);
 }
@@ -194,8 +194,7 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
     imageLabel->setScaledContents(true);
     imageLabel->setFixedSize(50, 50);
 
-    QLabel* titleLabel =
-        new QLabel("<h1>" + tr("Update Available - User Interface") + "</h1>", this);
+    QLabel* titleLabel = new QLabel("<h1>" + tr("Update Available - GUI") + "</h1>", this);
     titleLayout->addWidget(imageLabel);
     titleLayout->addWidget(titleLabel);
     layout->addLayout(titleLayout);

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -32,7 +32,7 @@ CheckUpdate::CheckUpdate(std::shared_ptr<gui_settings> gui_settings, const bool 
                          QWidget* parent)
     : QDialog(parent), m_gui_settings(std::move(gui_settings)),
       networkManager(new QNetworkAccessManager(this)) {
-    setWindowTitle(tr("Auto Updater - Interface"));
+    setWindowTitle(tr("Auto Updater - User Interface"));
     setFixedSize(0, 0);
     CheckForUpdates(showMessage);
 }
@@ -194,7 +194,8 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
     imageLabel->setScaledContents(true);
     imageLabel->setFixedSize(50, 50);
 
-    QLabel* titleLabel = new QLabel("<h1>" + tr("Update Available (Interface)") + "</h1>", this);
+    QLabel* titleLabel =
+        new QLabel("<h1>" + tr("Update Available - User Interface") + "</h1>", this);
     titleLayout->addWidget(imageLabel);
     titleLayout->addWidget(titleLabel);
     layout->addLayout(titleLayout);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -87,6 +87,7 @@ bool MainWindow::Init() {
     CheckUpdateMain(true);
 #endif
 
+    LoadVersionComboBox();
     if (m_gui_settings->GetValue(gui::vm_checkOnStartup).toBool()) {
         auto versionDialog = new VersionDialog(m_gui_settings, this);
         versionDialog->checkUpdatePre(false);
@@ -270,7 +271,6 @@ void MainWindow::AddUiWidgets() {
     versionLayout->addWidget(ui->versionManagerButton);
     ui->versionManagerButton->setText(tr("Version Manager"));
     ui->toolBar->addWidget(versionContainer);
-    LoadVersionComboBox();
 }
 
 void MainWindow::UpdateToolbarButtons() {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -913,7 +913,7 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Log Filter:\\nFilters the log to only print specific information.\\nExamples: \"Core:Trace\" \"Lib.Pad:Debug Common.Filesystem:Error\" \"*:Critical\"\\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.");
     #ifdef ENABLE_UPDATER
     } else if (elementName == "updaterGroupBox") {
-        text = tr("Auto Updater - User Interface:\\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.\\n\\n*This update applies only to the Qt user interface. To update the emulator core, please use the 'Version Manager' menu.");
+        text = tr("GUI Updates:\\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.\\n\\n*This update applies only to the Qt user interface. To update the emulator core, please use the 'Version Manager' menu.");
 #endif
     } else if (elementName == "GUIBackgroundImageGroupBox") {
         text = tr("Background Image:\\nControl the opacity of the game background image.");

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -815,9 +815,9 @@ void SettingsDialog::LoadValuesFromConfig() {
     }
     ui->chooseHomeTabComboBox->setCurrentText(translatedText);
 
-    QStringList tabNames = {tr("General"), tr("GUI"),   tr("Graphics"),
-                            tr("User"),    tr("Input"), tr("Paths"),
-                            tr("Log"),     tr("Debug"), tr("Experimental")};
+    QStringList tabNames = {tr("General"), tr("Frontend"), tr("Graphics"),
+                            tr("User"),    tr("Input"),    tr("Paths"),
+                            tr("Log"),     tr("Debug"),    tr("Experimental")};
     int indexTab = tabNames.indexOf(translatedText);
     if (indexTab == -1 || !ui->tabWidgetSettings->isTabVisible(indexTab) || is_newly_created)
         indexTab = 0;
@@ -913,7 +913,7 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Log Filter:\\nFilters the log to only print specific information.\\nExamples: \"Core:Trace\" \"Lib.Pad:Debug Common.Filesystem:Error\" \"*:Critical\"\\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.");
     #ifdef ENABLE_UPDATER
     } else if (elementName == "updaterGroupBox") {
-        text = tr("Update:\\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.");
+        text = tr("Auto Updater - User Interface:\\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.\\n\\n*This update applies only to the Qt user interface. To update the emulator core, please use the 'Version Manager' menu.");
 #endif
     } else if (elementName == "GUIBackgroundImageGroupBox") {
         text = tr("Background Image:\\nControl the opacity of the game background image.");

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -870,7 +870,7 @@
                </size>
               </property>
               <property name="title">
-               <string>Auto Updater - User Interface</string>
+               <string>GUI Updates</string>
               </property>
               <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0,0">
                <property name="spacing">

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -870,7 +870,7 @@
                </size>
               </property>
               <property name="title">
-               <string>Update</string>
+               <string>Auto Updater - User Interface</string>
               </property>
               <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0,0">
                <property name="spacing">

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -1116,11 +1116,10 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
                 dlg->close();
                 dlg->deleteLater();
 
-                 if (!QDir(destFolder).exists()) {
-                     QMessageBox::critical(this, tr("Error"),
-                                           tr("Extraction failure."));
-                     return;
-                 }
+                if (!QDir(destFolder).exists()) {
+                    QMessageBox::critical(this, tr("Error"), tr("Extraction failure."));
+                    return;
+                }
 
                 m_gui_settings->SetValue(gui::vm_versionSelected, destFolder);
 

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -52,7 +52,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
 
     ui->currentVersionPath->setText(m_gui_settings->GetValue(gui::vm_versionPath).toString());
 
-    LoadinstalledList();
+    LoadInstalledList();
 
     QStringList cachedVersions = LoadDownloadCache();
     if (!cachedVersions.isEmpty()) {
@@ -74,12 +74,12 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
             ui->currentVersionPath->setText(shad_folder_path_string);
             m_gui_settings->SetValue(gui::vm_versionPath, shad_folder_path_string);
             m_gui_settings->SetValue(gui::vm_versionSelected, "");
-            LoadinstalledList();
+            LoadInstalledList();
         }
     });
 
     connect(ui->checkChangesVersionButton, &QPushButton::clicked, this,
-            [this]() { LoadinstalledList(); });
+            [this]() { LoadInstalledList(); });
 
     connect(ui->addCustomVersionButton, &QPushButton::clicked, this, [this]() {
         QString exePath;
@@ -131,7 +131,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
         }
 
         QMessageBox::information(this, tr("Success"), tr("Version added successfully."));
-        LoadinstalledList();
+        LoadInstalledList();
     });
 
     connect(ui->deleteVersionButton, &QPushButton::clicked, this, [this]() {
@@ -163,7 +163,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
                     return;
                 }
             }
-            LoadinstalledList();
+            LoadInstalledList();
         }
     });
 
@@ -407,6 +407,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                 progressDialog->setWindowTitle(
                     tr("Downloading %1 , please wait...").arg(versionName));
                 progressDialog->setFixedSize(400, 80);
+                progressDialog->setWindowFlags(progressDialog->windowFlags() &
+                                               ~Qt::WindowCloseButtonHint);
                 QVBoxLayout* layout = new QVBoxLayout(progressDialog);
                 QProgressBar* progressBar = new QProgressBar(progressDialog);
                 progressBar->setRange(0, 100);
@@ -526,9 +528,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                         tr("Version %1 has been downloaded and selected.")
                                             .arg(versionName));
 
-                                    VersionDialog::LoadinstalledList();
+                                    LoadInstalledList();
                                 });
-
                         } else {
                             QMessageBox::warning(this, tr("Error"),
                                                  tr("Failed to create zip extraction script") +
@@ -540,7 +541,7 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
         });
 }
 
-void VersionDialog::LoadinstalledList() {
+void VersionDialog::LoadInstalledList() {
     QString path = m_gui_settings->GetValue(gui::vm_versionPath).toString();
     QDir dir(path);
     if (!dir.exists() || path.isEmpty())
@@ -1008,6 +1009,7 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
 
     dlg->setLayout(lay);
     dlg->resize(400, 80);
+    dlg->setWindowFlags(dlg->windowFlags() & ~Qt::WindowCloseButtonHint);
     dlg->show();
 
     QNetworkRequest req(downloadUrl);
@@ -1114,18 +1116,18 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
                 dlg->close();
                 dlg->deleteLater();
 
-                // if (!QDir(destFolder).exists()) {
-                //     QMessageBox::critical(this, tr("Error"),
-                //                           tr("Extraction failure."));
-                //     return;
-                // }
+                 if (!QDir(destFolder).exists()) {
+                     QMessageBox::critical(this, tr("Error"),
+                                           tr("Extraction failure."));
+                     return;
+                 }
 
                 m_gui_settings->SetValue(gui::vm_versionSelected, destFolder);
 
                 QMessageBox::information(this, tr("Complete installation"),
                                          tr("Pre-release updated successfully") + ":\n" + tagName);
 
-                LoadinstalledList();
+                LoadInstalledList();
             });
         } else {
             QMessageBox::warning(this, tr("Error"),

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -29,7 +29,7 @@ private:
     std::shared_ptr<gui_settings> m_gui_settings;
     QNetworkAccessManager* networkManager;
 
-    void LoadinstalledList();
+    void LoadInstalledList();
     QStringList LoadDownloadCache();
     void SaveDownloadCache(const QStringList& versions);
     void PopulateDownloadTree(const QStringList& versions);


### PR DESCRIPTION
- Added the text "**trophy.wav**" to Notice.txt and formatted it in the .cpp file for better readability;
- "Updater" (which updates QtLauncher) has been renamed to "**GUI Updates**";
- Attempted to fix LoadVersionComboBox, which sometimes failed to load when starting QtLauncher;
- Removed the close (X) button from the update download window while updates are in progress;
- Fixed the option to choose which tab opens by default — the 'Frontend' option was not working;
- Fixed the letter 'i' in LoadInstalledList :)

<img width="972" height="799" alt="image" src="https://github.com/user-attachments/assets/94a1cabf-46ac-4efe-8dae-b96b47153c07" />

