### PR TITLE
SDL event handling fix

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -18,12 +18,8 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
 
     ui->setupUi(this);
 
-    if (!GameRunning) {
-        SDL_InitSubSystem(SDL_INIT_GAMEPAD);
-        SDL_InitSubSystem(SDL_INIT_EVENTS);
-    } else {
-        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-    }
+    SDL_InitSubSystem(SDL_INIT_GAMEPAD);
+    SDL_InitSubSystem(SDL_INIT_EVENTS);
 
     AddBoxItems();
     SetUIValuestoMappings();
@@ -143,9 +139,7 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
     QObject::connect(RemapWrapper, &SdlEventWrapper::Wrapper::SDLEvent, this,
                      &ControlSettings::processSDLEvents);
 
-    if (!GameRunning) {
-        Polling = QtConcurrent::run(&ControlSettings::pollSDLEvents, this);
-    }
+    Polling = QtConcurrent::run(&ControlSettings::pollSDLEvents, this);
 }
 
 void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
@@ -1014,25 +1008,23 @@ void ControlSettings::Cleanup() {
         gamepad = nullptr;
     }
 
-    SDL_free(gamepads);
+    if (gamepads)
+        SDL_free(gamepads);
 
-    if (!GameRunning) {
-        SDL_Event quitLoop{};
-        quitLoop.type = SDL_EVENT_QUIT;
-        SDL_PushEvent(&quitLoop);
-        Polling.waitForFinished();
+    SDL_Event quitLoop{};
+    quitLoop.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&quitLoop);
+    Polling.waitForFinished();
 
-        SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
-        SDL_QuitSubSystem(SDL_INIT_EVENTS);
-        SDL_Quit();
-    } else {
-        /* if (!Config::getBackgroundControllerInput()) {
-            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
-        }
-        SDL_Event checkGamepad{};
-        checkGamepad.type = SDL_EVENT_CHANGE_CONTROLLER;
-        SDL_PushEvent(&checkGamepad); */
-    }
+    SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
+    SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    SDL_Quit();
+
+    /* TODO: IPC active gamepad
+    if (Config::getGameRunning()) {
+    SDL_Event checkGamepad{};
+    checkGamepad.type = SDL_EVENT_CHANGE_CONTROLLER;
+    SDL_PushEvent(&checkGamepad); */
 }
 
 ControlSettings::~ControlSettings() {}

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -20,12 +20,8 @@ Hotkeys::Hotkeys(bool isGameRunning, QWidget* parent)
 
     ui->setupUi(this);
 
-    if (!GameRunning) {
-        SDL_InitSubSystem(SDL_INIT_GAMEPAD);
-        SDL_InitSubSystem(SDL_INIT_EVENTS);
-    } else {
-        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-    }
+    SDL_InitSubSystem(SDL_INIT_GAMEPAD);
+    SDL_InitSubSystem(SDL_INIT_EVENTS);
 
     LoadHotkeys();
     CheckGamePad();
@@ -71,9 +67,7 @@ Hotkeys::Hotkeys(bool isGameRunning, QWidget* parent)
     QObject::connect(SdlEventWrapper::Wrapper::GetInstance(), &SdlEventWrapper::Wrapper::SDLEvent,
                      this, &Hotkeys::processSDLEvents);
 
-    if (!GameRunning) {
-        Polling = QtConcurrent::run(&Hotkeys::pollSDLEvents, this);
-    }
+    Polling = QtConcurrent::run(&Hotkeys::pollSDLEvents, this);
 }
 
 void Hotkeys::DisableMappingButtons() {
@@ -910,20 +904,14 @@ void Hotkeys::Cleanup() {
     if (h_gamepads)
         SDL_free(h_gamepads);
 
-    if (!GameRunning) {
-        SDL_Event quitLoop{};
-        quitLoop.type = SDL_EVENT_QUIT;
-        SDL_PushEvent(&quitLoop);
-        Polling.waitForFinished();
+    SDL_Event quitLoop{};
+    quitLoop.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&quitLoop);
+    Polling.waitForFinished();
 
-        SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
-        SDL_QuitSubSystem(SDL_INIT_EVENTS);
-        SDL_Quit();
-    } else {
-        if (!Config::getBackgroundControllerInput()) {
-            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
-        }
-    }
+    SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
+    SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    SDL_Quit();
 }
 
 Hotkeys::~Hotkeys() {}

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1298,7 +1298,7 @@ void SettingsDialog::onAudioDeviceChange(bool isAdd) {
     ui->DsAudioComboBox->clear();
 
     // prevent device list from refreshing too fast
-    if (isAdd == false)
+    if (!isAdd)
         QThread::msleep(100);
 
     int deviceCount;

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -577,15 +577,8 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->dmemGroupBox->installEventFilter(this);
     }
 
-    SdlEventWrapper::Wrapper::wrapperActive = true;
-    if (!is_game_running) {
-        SDL_InitSubSystem(SDL_INIT_EVENTS);
-        Polling = QtConcurrent::run(&SettingsDialog::pollSDLevents, this);
-    } else {
-        SdlEventWrapper::Wrapper* DeviceEventWrapper = SdlEventWrapper::Wrapper::GetInstance();
-        QObject::connect(DeviceEventWrapper, &SdlEventWrapper::Wrapper::audioDeviceChanged, this,
-                         &SettingsDialog::onAudioDeviceChange);
-    }
+    SDL_InitSubSystem(SDL_INIT_EVENTS);
+    Polling = QtConcurrent::run(&SettingsDialog::pollSDLevents, this);
 }
 
 void SettingsDialog::closeEvent(QCloseEvent* event) {
@@ -597,19 +590,17 @@ void SettingsDialog::closeEvent(QCloseEvent* event) {
         SyncRealTimeWidgetstoConfig();
     }
 
-    SdlEventWrapper::Wrapper::wrapperActive = false;
-    if (!is_game_running) {
-        SDL_Event quitLoop{};
-        quitLoop.type = SDL_EVENT_QUIT;
-        SDL_PushEvent(&quitLoop);
-        Polling.waitForFinished();
+    SDL_Event quitLoop{};
+    quitLoop.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&quitLoop);
+    Polling.waitForFinished();
 
-        SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    SDL_QuitSubSystem(SDL_INIT_EVENTS);
 
-        // This breaks the microphone selection
-        // SDL_QuitSubSystem(SDL_INIT_AUDIO);
-        // SDL_Quit();
-    }
+    // This breaks the microphone selection
+    // SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    // SDL_Quit();
+
     QDialog::closeEvent(event);
 }
 
@@ -1306,8 +1297,8 @@ void SettingsDialog::onAudioDeviceChange(bool isAdd) {
     ui->GenAudioComboBox->clear();
     ui->DsAudioComboBox->clear();
 
-    // prevent device list from refreshing too fast when game not running
-    if (!is_game_running && isAdd == false)
+    // prevent device list from refreshing too fast
+    if (isAdd == false)
         QThread::msleep(100);
 
     int deviceCount;


### PR DESCRIPTION
The sdl event handling code for the GUI was originally written to share the sdl event loop with the game's sdl loop when a game is running. With this separated launcher, there is no more game sdl loop in the app, so the sdl events are not processed when the game is running. 

Rewrites the affected sdl event code in the controller remapping, hotkeys, and settings dialog to allow their sdl events to be processed while a game is running