### PR TITLE
IPC client: functions for volume adjustment, input parsing, fsr, gamepad select

### DIFF
--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -58,9 +58,30 @@ void IpcClient::toggleFullscreen() {
     writeLine("TOGGLE_FULLSCREEN");
 }
 
-void IpcClient::adjustVol(int gain) {
+void IpcClient::adjustVol(int volume, bool is_game_specific) {
     writeLine("ADJUST_VOLUME");
-    writeLine(QString::number(gain));
+    writeLine(QString::number(volume));
+    writeLine(is_game_specific ? "1" : "0");
+}
+
+void IpcClient::setFsr(bool enable) {
+    writeLine("SET_FSR");
+    writeLine(enable ? "1" : "0");
+}
+
+void IpcClient::setRcas(bool enable) {
+    writeLine("SET_RCAS");
+    writeLine(enable ? "1" : "0");
+}
+
+void IpcClient::setRcasAttenuation(int value) {
+    writeLine("SET_RCAS_ATTENUATION");
+    writeLine(QString::number(value));
+}
+
+void IpcClient::reloadInputs(std::string config) {
+    writeLine("RELOAD_INPUTS");
+    writeLine(QString::fromStdString(config));
 }
 
 void IpcClient::sendMemoryPatches(std::string modNameStr, std::string offsetStr,

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -84,6 +84,11 @@ void IpcClient::reloadInputs(std::string config) {
     writeLine(QString::fromStdString(config));
 }
 
+void IpcClient::setActiveController(std::string GUID) {
+    writeLine("SET_ACTIVE_CONTROLLER");
+    writeLine(QString::fromStdString(GUID));
+}
+
 void IpcClient::sendMemoryPatches(std::string modNameStr, std::string offsetStr,
                                   std::string valueStr, std::string targetStr, std::string sizeStr,
                                   bool isOffset, bool littleEndian,

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -58,6 +58,11 @@ void IpcClient::toggleFullscreen() {
     writeLine("TOGGLE_FULLSCREEN");
 }
 
+void IpcClient::adjustVol(int gain) {
+    writeLine("ADJUST_VOLUME");
+    writeLine(QString::number(gain));
+}
+
 void IpcClient::sendMemoryPatches(std::string modNameStr, std::string offsetStr,
                                   std::string valueStr, std::string targetStr, std::string sizeStr,
                                   bool isOffset, bool littleEndian,

--- a/src/ipc/ipc_client.h
+++ b/src/ipc/ipc_client.h
@@ -22,6 +22,7 @@ public:
     void stopEmulator();
     void restartEmulator();
     void toggleFullscreen();
+    void adjustVol(int gain);
     void sendMemoryPatches(std::string modNameStr, std::string offsetStr, std::string valueStr,
                            std::string targetStr, std::string sizeStr, bool isOffset,
                            bool littleEndian,

--- a/src/ipc/ipc_client.h
+++ b/src/ipc/ipc_client.h
@@ -27,6 +27,7 @@ public:
     void setRcas(bool enable);
     void setRcasAttenuation(int value);
     void reloadInputs(std::string config);
+    void setActiveController(std::string GUID);
     void sendMemoryPatches(std::string modNameStr, std::string offsetStr, std::string valueStr,
                            std::string targetStr, std::string sizeStr, bool isOffset,
                            bool littleEndian,

--- a/src/ipc/ipc_client.h
+++ b/src/ipc/ipc_client.h
@@ -22,7 +22,11 @@ public:
     void stopEmulator();
     void restartEmulator();
     void toggleFullscreen();
-    void adjustVol(int gain);
+    void adjustVol(int volume, bool game_specific);
+    void setFsr(bool enable);
+    void setRcas(bool enable);
+    void setRcasAttenuation(int value);
+    void reloadInputs(std::string config);
     void sendMemoryPatches(std::string modNameStr, std::string offsetStr, std::string valueStr,
                            std::string targetStr, std::string sizeStr, bool isOffset,
                            bool littleEndian,

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -11,10 +11,12 @@
 #include "input/controller.h"
 #include "ui_control_settings.h"
 
-ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGameRunning,
+ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get,
+                                 std::shared_ptr<IpcClient> ipc_client, bool isGameRunning,
                                  std::string GameRunningSerial, QWidget* parent)
-    : QDialog(parent), m_game_info(game_info_get), GameRunning(isGameRunning),
-      RunningGameSerial(GameRunningSerial), ui(new Ui::ControlSettings) {
+    : QDialog(parent), m_game_info(game_info_get), m_ipc_client(ipc_client),
+      GameRunning(isGameRunning), RunningGameSerial(GameRunningSerial),
+      ui(new Ui::ControlSettings) {
 
     ui->setupUi(this);
 
@@ -344,8 +346,8 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     Config::save(Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "config.toml");
 
     if (GameRunning) {
-        // Config::GetUseUnifiedInputConfig() ? Input::ParseInputConfig("default")
-        //                                    : Input::ParseInputConfig(RunningGameSerial);
+        Config::GetUseUnifiedInputConfig() ? m_ipc_client->reloadInputs("default")
+                                           : m_ipc_client->reloadInputs(RunningGameSerial);
     }
 
     if (CloseOnSave)

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -1022,11 +1022,7 @@ void ControlSettings::Cleanup() {
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
     SDL_Quit();
 
-    /* TODO: IPC active gamepad
-    if (Config::getGameRunning()) {
-    SDL_Event checkGamepad{};
-    checkGamepad.type = SDL_EVENT_CHANGE_CONTROLLER;
-    SDL_PushEvent(&checkGamepad); */
+    m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
 }
 
 ControlSettings::~ControlSettings() {}

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -5,6 +5,7 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gamepad.h>
 #include "game_info.h"
+#include "ipc/ipc_client.h"
 #include "sdl_event_wrapper.h"
 
 namespace Ui {
@@ -14,7 +15,8 @@ class ControlSettings;
 class ControlSettings : public QDialog {
     Q_OBJECT
 public:
-    explicit ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
+    explicit ControlSettings(std::shared_ptr<GameInfoClass> game_info_get,
+                             std::shared_ptr<IpcClient> ipc_client, bool GameRunning,
                              std::string GameRunningSerial, QWidget* parent = nullptr);
     ~ControlSettings();
 
@@ -34,6 +36,7 @@ private Q_SLOTS:
 private:
     std::unique_ptr<Ui::ControlSettings> ui;
     std::shared_ptr<GameInfoClass> m_game_info;
+    std::shared_ptr<IpcClient> m_ipc_client;
 
     bool eventFilter(QObject* obj, QEvent* event) override;
     void AddBoxItems();

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -15,7 +15,6 @@ GameListFrame::GameListFrame(std::shared_ptr<gui_settings> gui_settings,
                              std::shared_ptr<IpcClient> ipc_client, QWidget* parent)
     : QTableWidget(parent), m_gui_settings(std::move(gui_settings)), m_game_info(game_info_get),
       m_compat_info(compat_info_get), m_ipc_client(ipc_client) {
-
     icon_size = m_gui_settings->GetValue(gui::gl_icon_size).toInt();
     last_favorite = "";
     this->setShowGrid(false);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -436,8 +436,9 @@ public:
         }
 
         if (selected == &gameConfigConfigure || selected == &gameConfigCreate) {
-            auto settingsWindow = new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client,
-                                                     widget, false, true, serialStr.toStdString());
+            auto settingsWindow =
+                new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client, widget,
+                                   Config::getGameRunning(), true, serialStr.toStdString());
             settingsWindow->exec();
         }
 

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -436,8 +436,8 @@ public:
         }
 
         if (selected == &gameConfigConfigure || selected == &gameConfigCreate) {
-            auto settingsWindow = new SettingsDialog(m_gui_settings, m_compat_info, widget, false,
-                                                     true, serialStr.toStdString());
+            auto settingsWindow = new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client,
+                                                     widget, false, true, serialStr.toStdString());
             settingsWindow->exec();
         }
 

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -15,8 +15,8 @@
 #include "sdl_event_wrapper.h"
 #include "ui_hotkeys.h"
 
-Hotkeys::Hotkeys(bool isGameRunning, QWidget* parent)
-    : QDialog(parent), GameRunning(isGameRunning), ui(new Ui::Hotkeys) {
+Hotkeys::Hotkeys(std::shared_ptr<IpcClient> ipc_client, bool isGameRunning, QWidget* parent)
+    : QDialog(parent), m_ipc_client(ipc_client), GameRunning(isGameRunning), ui(new Ui::Hotkeys) {
 
     ui->setupUi(this);
 
@@ -235,8 +235,8 @@ void Hotkeys::SaveHotkeys(bool CloseOnSave) {
     output_file.close();
 
     // this also parses global hotkeys
-    // if (GameRunning)
-    // Input::ParseInputConfig("default");
+    if (GameRunning)
+        m_ipc_client->reloadInputs("default");
 
     if (CloseOnSave)
         QWidget::close();

--- a/src/qt_gui/hotkeys.h
+++ b/src/qt_gui/hotkeys.h
@@ -6,6 +6,8 @@
 #include <QTimer>
 #include <SDL3/SDL_gamepad.h>
 
+#include "ipc/ipc_client.h"
+
 #ifdef _WIN32
 #define LCTRL_KEY 29
 #define LALT_KEY 56
@@ -24,7 +26,8 @@ class Hotkeys : public QDialog {
     Q_OBJECT
 
 public:
-    explicit Hotkeys(bool GameRunning, QWidget* parent = nullptr);
+    explicit Hotkeys(std::shared_ptr<IpcClient> ipc_client, bool GameRunning,
+                     QWidget* parent = nullptr);
     ~Hotkeys();
 
 private Q_SLOTS:
@@ -43,6 +46,8 @@ private:
     void CheckGamePad();
     void SetMapping(QString input);
     void Cleanup();
+
+    std::shared_ptr<IpcClient> m_ipc_client;
 
     bool GameRunning;
     bool EnablePadMapping = false;

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -16,10 +16,11 @@
 #include "ui_kbm_gui.h"
 
 HelpDialog* HelpWindow;
-KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGameRunning,
+KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
+                         std::shared_ptr<IpcClient> ipc_client, bool isGameRunning,
                          std::string GameRunningSerial, QWidget* parent)
-    : QDialog(parent), m_game_info(game_info_get), GameRunning(isGameRunning),
-      RunningGameSerial(GameRunningSerial), ui(new Ui::KBMSettings) {
+    : QDialog(parent), m_game_info(game_info_get), m_ipc_client(ipc_client),
+      GameRunning(isGameRunning), RunningGameSerial(GameRunningSerial), ui(new Ui::KBMSettings) {
 
     ui->setupUi(this);
     ui->PerGameCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
@@ -341,8 +342,8 @@ QString(tr("Cannot bind any unique input more than once. Duplicate inputs mapped
     Config::save(Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "config.toml");
 
     if (GameRunning) {
-        // Config::GetUseUnifiedInputConfig() ? Input::ParseInputConfig("default")
-        //                                    : Input::ParseInputConfig(RunningGameSerial);
+        Config::GetUseUnifiedInputConfig() ? m_ipc_client->reloadInputs("default")
+                                           : m_ipc_client->reloadInputs(RunningGameSerial);
     }
 
     if (close_on_save)

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <QDialog>
+
 #include "game_info.h"
+#include "ipc/ipc_client.h"
 
 // macros > declaring constants
 // also, we were only using one counterpart
@@ -23,7 +25,8 @@ class KBMSettings;
 class KBMSettings : public QDialog {
     Q_OBJECT
 public:
-    explicit KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
+    explicit KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
+                         std::shared_ptr<IpcClient> ipc_client, bool GameRunning,
                          std::string GameRunningSerial, QWidget* parent = nullptr);
     ~KBMSettings();
 
@@ -40,6 +43,7 @@ private Q_SLOTS:
 private:
     std::unique_ptr<Ui::KBMSettings> ui;
     std::shared_ptr<GameInfoClass> m_game_info;
+    std::shared_ptr<IpcClient> m_ipc_client;
 
     bool eventFilter(QObject* obj, QEvent* event) override;
     void ButtonConnects();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -22,6 +22,7 @@
 #include "control_settings.h"
 #include "game_install_dialog.h"
 #include "hotkeys.h"
+#include "input/controller.h"
 #include "ipc/ipc_client.h"
 #include "kbm_gui.h"
 #include "main_window.h"
@@ -1301,6 +1302,7 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
     QString workDir = fileInfo.absolutePath();
 
     m_ipc_client->startEmulator(fileInfo, final_args, workDir);
+    m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
 }
 
 void MainWindow::RunGame() {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -486,19 +486,20 @@ void MainWindow::CreateConnects() {
 
         connect(settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this,
                 [this](int opacity) {
-            m_gui_settings->SetValue(gui::gl_backgroundImageOpacity, std::clamp(opacity, 0, 100));
-            if (m_game_list_frame) {
-                QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
-                if (current) {
-                    m_game_list_frame->SetListBackgroundImage(current);
-                }
-            }
-            if (m_game_grid_frame) {
-                if (m_game_grid_frame->IsValidCellSelected()) {
-                    m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
-                                                              m_game_grid_frame->crtColumn);
-                }
-            }
+                    m_gui_settings->SetValue(gui::gl_backgroundImageOpacity,
+                                             std::clamp(opacity, 0, 100));
+                    if (m_game_list_frame) {
+                        QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
+                        if (current) {
+                            m_game_list_frame->SetListBackgroundImage(current);
+                        }
+                    }
+                    if (m_game_grid_frame) {
+                        if (m_game_grid_frame->IsValidCellSelected()) {
+                            m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
+                                                                      m_game_grid_frame->crtColumn);
+                        }
+                    }
                 });
 
         settingsDialog->exec();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -471,8 +471,8 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->settingsButton, &QPushButton::clicked, this, [this]() {
-        auto settingsDialog =
-            new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client, this, Config::getGameRunning();
+        auto settingsDialog = new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client, this,
+                                                 Config::getGameRunning());
 
         connect(settingsDialog, &SettingsDialog::LanguageChanged, this,
                 &MainWindow::OnLanguageChanged);
@@ -505,14 +505,14 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->controllerButton, &QPushButton::clicked, this, [this]() {
-        ControlSettings* remapWindow =
-            new ControlSettings(m_game_info, Config::getGameRunning(), runningGameSerial, this);
+        ControlSettings* remapWindow = new ControlSettings(
+            m_game_info, m_ipc_client, Config::getGameRunning(), runningGameSerial, this);
         remapWindow->exec();
     });
 
     connect(ui->keyboardButton, &QPushButton::clicked, this, [this]() {
-        auto kbmWindow =
-            new KBMSettings(m_game_info, Config::getGameRunning(), runningGameSerial, this);
+        auto kbmWindow = new KBMSettings(m_game_info, m_ipc_client, Config::getGameRunning(),
+                                         runningGameSerial, this);
         kbmWindow->exec();
     });
 
@@ -535,7 +535,7 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->configureHotkeys, &QAction::triggered, this, [this]() {
-        auto hotkeyDialog = new Hotkeys(Config::getGameRunning(), this);
+        auto hotkeyDialog = new Hotkeys(m_ipc_client, Config::getGameRunning(), this);
         hotkeyDialog->exec();
     });
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -436,8 +436,8 @@ void MainWindow::CreateConnects() {
             &MainWindow::StartGame);
 
     connect(ui->configureAct, &QAction::triggered, this, [this]() {
-        auto settingsDialog =
-            new SettingsDialog(m_gui_settings, m_compat_info, this, Config::getGameRunning());
+        auto settingsDialog = new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client, this,
+                                                 Config::getGameRunning());
 
         connect(settingsDialog, &SettingsDialog::LanguageChanged, this,
                 &MainWindow::OnLanguageChanged);
@@ -472,7 +472,7 @@ void MainWindow::CreateConnects() {
 
     connect(ui->settingsButton, &QPushButton::clicked, this, [this]() {
         auto settingsDialog =
-            new SettingsDialog(m_gui_settings, m_compat_info, this, Config::getGameRunning());
+            new SettingsDialog(m_gui_settings, m_compat_info, m_ipc_client, this, Config::getGameRunning();
 
         connect(settingsDialog, &SettingsDialog::LanguageChanged, this,
                 &MainWindow::OnLanguageChanged);
@@ -486,20 +486,19 @@ void MainWindow::CreateConnects() {
 
         connect(settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this,
                 [this](int opacity) {
-                    m_gui_settings->SetValue(gui::gl_backgroundImageOpacity,
-                                             std::clamp(opacity, 0, 100));
-                    if (m_game_list_frame) {
-                        QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
-                        if (current) {
-                            m_game_list_frame->SetListBackgroundImage(current);
-                        }
-                    }
-                    if (m_game_grid_frame) {
-                        if (m_game_grid_frame->IsValidCellSelected()) {
-                            m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
-                                                                      m_game_grid_frame->crtColumn);
-                        }
-                    }
+            m_gui_settings->SetValue(gui::gl_backgroundImageOpacity, std::clamp(opacity, 0, 100));
+            if (m_game_list_frame) {
+                QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
+                if (current) {
+                    m_game_list_frame->SetListBackgroundImage(current);
+                }
+            }
+            if (m_game_grid_frame) {
+                if (m_game_grid_frame->IsValidCellSelected()) {
+                    m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
+                                                              m_game_grid_frame->crtColumn);
+                }
+            }
                 });
 
         settingsDialog->exec();

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -82,10 +82,11 @@ static std::vector<QString> m_physical_devices;
 
 SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
                                std::shared_ptr<CompatibilityInfoClass> m_compat_info,
-                               QWidget* parent, bool is_running, bool is_specific,
-                               std::string gsc_serial)
+                               std::shared_ptr<IpcClient> ipc_client, QWidget* parent,
+                               bool is_running, bool is_specific, std::string gsc_serial)
     : QDialog(parent), ui(new Ui::SettingsDialog), m_gui_settings(std::move(gui_settings)),
-      is_game_running(is_running), is_game_specific(is_specific), gs_serial(gsc_serial) {
+      m_ipc_client(ipc_client), is_game_running(is_running), is_game_specific(is_specific),
+      gs_serial(gsc_serial) {
 
     ui->setupUi(this);
     ui->tabWidgetSettings->setUsesScrollButtons(false);
@@ -237,8 +238,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     {
         connect(ui->horizontalVolumeSlider, &QSlider::valueChanged, this, [this](int value) {
             VolumeSliderChange(value);
-            Config::setVolumeSlider(value, is_game_specific);
-            // Libraries::AudioOut::AdjustVol();
+            m_ipc_client->adjustVol(value);
         });
 
 #ifdef ENABLE_UPDATER

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -238,7 +238,9 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     {
         connect(ui->horizontalVolumeSlider, &QSlider::valueChanged, this, [this](int value) {
             VolumeSliderChange(value);
-            m_ipc_client->adjustVol(value);
+
+            if (Config::getGameRunning())
+                m_ipc_client->adjustVol(value, is_game_specific);
         });
 
 #ifdef ENABLE_UPDATER
@@ -465,28 +467,24 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->RCASValue->setText(RCASValue);
     });
 
-    //     if (presenter) {
-    //         connect(ui->RCASSlider, &QSlider::valueChanged, this, [this](int value) {
-    //             presenter->GetFsrSettingsRef().rcas_attenuation = static_cast<float>(value /
-    //             1000.0f);
-    //         });
+    if (Config::getGameRunning()) {
+        connect(ui->RCASSlider, &QSlider::valueChanged, this,
+                [this](int value) { m_ipc_client->setRcasAttenuation(value); });
 
-    // #if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
-    //         connect(ui->FSRCheckBox, &QCheckBox::stateChanged, this,
-    //                 [this](int state) { presenter->GetFsrSettingsRef().enable = state; });
+#if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
+        connect(ui->FSRCheckBox, &QCheckBox::stateChanged, this,
+                [this](int state) { m_ipc_client->setFsr(state); });
 
-    //         connect(ui->RCASCheckBox, &QCheckBox::stateChanged, this,
-    //                 [this](int state) { presenter->GetFsrSettingsRef().use_rcas = state; });
-    // #else
-    //         connect(ui->FSRCheckBox, &QCheckBox::checkStateChanged, this,
-    //                 [this](Qt::CheckState state) { presenter->GetFsrSettingsRef().enable = state;
-    //                 });
+        connect(ui->RCASCheckBox, &QCheckBox::stateChanged, this,
+                [this](int state) { m_ipc_client->setRcas(state); });
+#else
+        connect(ui->FSRCheckBox, &QCheckBox::checkStateChanged, this,
+                [this](Qt::CheckState state) { m_ipc_client->setFsr(state); });
 
-    //         connect(ui->RCASCheckBox, &QCheckBox::checkStateChanged, this,
-    //                 [this](Qt::CheckState state) { presenter->GetFsrSettingsRef().use_rcas =
-    //                 state; });
-    // #endif
-    //     }
+        connect(ui->RCASCheckBox, &QCheckBox::checkStateChanged, this,
+                [this](Qt::CheckState state) { m_ipc_client->setRcas(state); });
+#endif
+    }
 
     // Descriptions
     {
@@ -1239,15 +1237,12 @@ void SettingsDialog::SyncRealTimeWidgetstoConfig() {
     is_game_specific ? Config::resetGameSpecificValue("volumeSlider")
                      : Config::setVolumeSlider(sliderValue);
 
-    // if (presenter) {
-    //     presenter->GetFsrSettingsRef().enable =
-    //         toml::find_or<bool>(gs_data, "GPU", "fsrEnabled", true);
-    //     presenter->GetFsrSettingsRef().use_rcas =
-    //         toml::find_or<bool>(gs_data, "GPU", "rcasEnabled", true);
-    //     presenter->GetFsrSettingsRef().rcas_attenuation =
-    //         static_cast<float>(toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250) /
-    //         1000.f);
-    // }
+    if (Config::getGameRunning()) {
+        m_ipc_client->setFsr(toml::find_or<bool>(gs_data, "GPU", "fsrEnabled", true));
+        m_ipc_client->setRcas(toml::find_or<bool>(gs_data, "GPU", "rcasEnabled", true));
+        m_ipc_client->setRcasAttenuation(
+            toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250));
+    }
 }
 
 void SettingsDialog::setDefaultValues() {

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -12,6 +12,7 @@
 #include "common/config.h"
 #include "common/path_util.h"
 #include "gui_settings.h"
+#include "ipc/ipc_client.h"
 #include "qt_gui/compatibility_info.h"
 
 namespace Ui {
@@ -23,8 +24,9 @@ class SettingsDialog : public QDialog {
 public:
     explicit SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
                             std::shared_ptr<CompatibilityInfoClass> m_compat_info,
-                            QWidget* parent = nullptr, bool is_game_running = false,
-                            bool is_game_specific = false, std::string gsc_serial = "");
+                            std::shared_ptr<IpcClient> ipc_client, QWidget* parent = nullptr,
+                            bool is_game_running = false, bool is_game_specific = false,
+                            std::string gsc_serial = "");
     ~SettingsDialog();
 
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -66,5 +68,6 @@ private:
     bool is_game_saving = false;
 
     std::shared_ptr<gui_settings> m_gui_settings;
+    std::shared_ptr<IpcClient> m_ipc_client;
     QFuture<void> Polling;
 };


### PR DESCRIPTION
Client-side implementation for https://github.com/shadps4-emu/shadPS4/pull/3734, for the ff features:

1. Realtime in-game volume adjustment
2. Automatically reload bindings when remapping/hotkey dialogs are saved
3. Realtime in-game fsr adjustment
4. Support changing active controller in the GUI