### PR TITLE
Make all builds use the current local user folder

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1298,7 +1298,7 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
 
     final_args.append(args);
 
-    QString workDir = fileInfo.absolutePath();
+    QString workDir = QDir::currentPath();
 
     m_ipc_client->startEmulator(fileInfo, final_args, workDir);
 }


### PR DESCRIPTION
This should make portable user folders work, as the previously set working directory of "right beside the executable" doesn't make a lot of sense.