### PR TITLE
Silence unknown log class errors

### DIFF
--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -52,7 +52,6 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
 
     const Class log_class = GetClassByName(begin, level_separator);
     if (log_class == Class::Count) {
-        LOG_ERROR(Log, "Unknown log class in filter: {}", std::string(begin, end));
         return false;
     }
 


### PR DESCRIPTION
```
[Log] <Error> filter.cpp:55 ParseFilterRule: Unknown log class in filter: Lib.Libc:Info
[Log] <Error> filter.cpp:55 ParseFilterRule: Unknown log class in filter: Lib.Fios2:Debug
[Log] <Error> filter.cpp:55 ParseFilterRule: Unknown log class in filter: Core.Hooking:Info
[Log] <Error> filter.cpp:55 ParseFilterRule: Unknown log class in filter: Lib.NpSnsFacebookDialog:Critical
```
Errors like this don't really make sense for the launcher, and as more and more time passes, there will be a lot more log classes that the launcher doesn't know about, but the emulator does, so I just silenced this.