### PR TITLE
Fix ipc double-free crash and remapping dialog errors

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -36,7 +36,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     ui->toggleLabelsAct->setChecked(
         m_gui_settings->GetValue(gui::mw_showLabelsUnderIcons).toBool());
 
-    m_ipc_client = std::make_shared<IpcClient>(this);
     m_ipc_client->gameClosedFunc = [this]() { onGameClosed(); };
     m_ipc_client->restartEmulatorFunc = [this]() { RestartEmulator(); };
     m_ipc_client->startGameFunc = [this]() { RunGame(); };

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -110,7 +110,7 @@ private:
     QTranslator* translator;
     std::shared_ptr<gui_settings> m_gui_settings;
 
-    std::shared_ptr<IpcClient> m_ipc_client;
+    std::shared_ptr<IpcClient> m_ipc_client = std::make_shared<IpcClient>();
     std::filesystem::path last_game_path;
 
 protected:


### PR DESCRIPTION
Fixes ipc make_shared pointers to prevent double free crash.

Fixes https://github.com/shadps4-emu/shadps4-qtlauncher/issues/113.

Fixes an error message sometimes incorrectly shown on startup.