### PR TITLE
Transfer home tab setting to frontend tab + checkgamepad fix

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -708,7 +708,7 @@ void ControlSettings::CheckGamePad() {
     } else if (defaultIndex != -1) {
         gamepad = SDL_OpenGamepad(gamepads[defaultIndex]);
     } else {
-        LOG_TRACE(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
+        LOG_INFO(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
         gamepad = SDL_OpenGamepad(gamepads[0]);
     }
 
@@ -980,7 +980,7 @@ void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
         }
     }
 
-    if (Type == SDL_EVENT_GAMEPAD_ADDED || SDL_EVENT_GAMEPAD_REMOVED) {
+    if (Type == SDL_EVENT_GAMEPAD_ADDED || Type == SDL_EVENT_GAMEPAD_REMOVED) {
         ui->ActiveGamepadBox->clear();
         CheckGamePad();
     }

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -708,7 +708,7 @@ void ControlSettings::CheckGamePad() {
     } else if (defaultIndex != -1) {
         gamepad = SDL_OpenGamepad(gamepads[defaultIndex]);
     } else {
-        LOG_INFO(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
+        LOG_TRACE(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
         gamepad = SDL_OpenGamepad(gamepads[0]);
     }
 

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -310,6 +310,8 @@ void Hotkeys::CheckGamePad() {
     if (!h_gamepads) {
         LOG_ERROR(Input, "Cannot get gamepad list: {}", SDL_GetError());
         return;
+    } else if (gamepad_count == 0) {
+        return;
     }
 
     int defaultIndex = GamepadSelect::GetIndexfromGUID(h_gamepads, gamepad_count,
@@ -317,19 +319,17 @@ void Hotkeys::CheckGamePad() {
     int activeIndex = GamepadSelect::GetIndexfromGUID(h_gamepads, gamepad_count,
                                                       GamepadSelect::GetSelectedGamepad());
 
-    if (!GameRunning) {
-        if (activeIndex != -1) {
-            h_gamepad = SDL_OpenGamepad(h_gamepads[activeIndex]);
-        } else if (defaultIndex != -1) {
-            h_gamepad = SDL_OpenGamepad(h_gamepads[defaultIndex]);
-        } else {
-            LOG_INFO(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
-            h_gamepad = SDL_OpenGamepad(h_gamepads[0]);
-        }
+    if (activeIndex != -1) {
+        h_gamepad = SDL_OpenGamepad(h_gamepads[activeIndex]);
+    } else if (defaultIndex != -1) {
+        h_gamepad = SDL_OpenGamepad(h_gamepads[defaultIndex]);
+    } else {
+        LOG_INFO(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
+        h_gamepad = SDL_OpenGamepad(h_gamepads[0]);
+    }
 
-        if (!h_gamepad) {
-            LOG_ERROR(Input, "Failed to open gamepad: {}", SDL_GetError());
-        }
+    if (!h_gamepad) {
+        LOG_ERROR(Input, "Failed to open gamepad: {}", SDL_GetError());
     }
 }
 
@@ -873,7 +873,7 @@ void Hotkeys::processSDLEvents(int Type, int Input, int Value) {
             CheckMapping(MappingButton);
     }
 
-    if (Type == SDL_EVENT_GAMEPAD_ADDED || SDL_EVENT_GAMEPAD_REMOVED) {
+    if (Type == SDL_EVENT_GAMEPAD_ADDED || Type == SDL_EVENT_GAMEPAD_REMOVED) {
         CheckGamePad();
     }
 }

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>970</width>
-    <height>767</height>
+    <height>769</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>7</number>
+      <number>0</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -77,7 +77,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>503</height>
+         <height>505</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -89,6 +89,18 @@
           <property name="spacing">
            <number>6</number>
           </property>
+          <item row="1" column="0">
+           <widget class="QGroupBox" name="GenAudioGroupBox">
+            <property name="title">
+             <string>Audio Device (general)</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8">
+             <item>
+              <widget class="QComboBox" name="GenAudioComboBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="0" column="2">
            <layout class="QVBoxLayout" name="emulatorTabLayoutMiddle">
             <property name="leftMargin">
@@ -117,7 +129,7 @@
               <property name="checkable">
                <bool>false</bool>
               </property>
-              <layout class="QVBoxLayout" name="additionalSettingsVLayout" stretch="0,0,0">
+              <layout class="QVBoxLayout" name="additionalSettingsVLayout" stretch="0,0">
                <property name="spacing">
                 <number>6</number>
                </property>
@@ -133,76 +145,6 @@
                <property name="bottomMargin">
                 <number>9</number>
                </property>
-               <item>
-                <widget class="QGroupBox" name="chooseHomeTabGroupBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="title">
-                  <string>Default tab when opening settings</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="tabSettingsLayout">
-                  <item>
-                   <widget class="QComboBox" name="chooseHomeTabComboBox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>General</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Frontend</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Graphics</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>User</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Input</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Paths</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Log</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Debug</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Experimental</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
                <item>
                 <widget class="QCheckBox" name="showSplashCheckBox">
                  <property name="text">
@@ -227,32 +169,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="2" column="0">
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="2">
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="0" column="0">
            <layout class="QVBoxLayout" name="systemTabLayoutLeft">
@@ -320,8 +236,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>98</width>
-                       <height>47</height>
+                       <width>531</width>
+                       <height>68</height>
                       </rect>
                      </property>
                      <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -381,18 +297,6 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QGroupBox" name="GenAudioGroupBox">
-            <property name="title">
-             <string>Audio Device (general)</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_8">
-             <item>
-              <widget class="QComboBox" name="GenAudioComboBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="2" column="0">
            <widget class="QGroupBox" name="DsSpeakerGroupBox">
             <property name="title">
@@ -422,8 +326,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>932</width>
-         <height>504</height>
+         <width>946</width>
+         <height>505</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -442,7 +346,7 @@
            <number>0</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="GUITabLayoutMiddle" stretch="0,0">
+           <layout class="QVBoxLayout" name="GUITabLayoutMiddle" stretch="0,0,0">
             <property name="bottomMargin">
              <number>0</number>
             </property>
@@ -709,44 +613,44 @@
                  </widget>
                 </widget>
                </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="title">
+               <string>Trophy Key</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
-                <widget class="QGroupBox" name="groupBox">
-                 <property name="title">
-                  <string>Trophy Key</string>
+                <layout class="QHBoxLayout" name="horizontalLayout_trophyKey">
+                 <property name="bottomMargin">
+                  <number>0</number>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_6">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_trophyKey">
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <widget class="QLabel" name="label_Trophy">
-                      <property name="text">
-                       <string>Trophy Key</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="trophyKeyLineEdit">
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="font">
-                       <font>
-                        <pointsize>10</pointsize>
-                        <bold>false</bold>
-                       </font>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
+                 <item>
+                  <widget class="QLabel" name="label_Trophy">
+                   <property name="text">
+                    <string>Trophy Key</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="trophyKeyLineEdit">
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <pointsize>10</pointsize>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>
@@ -767,7 +671,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="CompatTabLayoutRight" stretch="0,0,0">
+           <layout class="QVBoxLayout" name="CompatTabLayoutRight" stretch="0,0,0,0">
             <property name="spacing">
              <number>6</number>
             </property>
@@ -872,19 +776,7 @@
               <property name="title">
                <string>GUI Updates</string>
               </property>
-              <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0,0">
-               <property name="spacing">
-                <number>6</number>
-               </property>
-               <property name="topMargin">
-                <number>9</number>
-               </property>
-               <property name="rightMargin">
-                <number>9</number>
-               </property>
-               <property name="bottomMargin">
-                <number>80</number>
-               </property>
+              <layout class="QVBoxLayout" name="verticalLayout_13">
                <item>
                 <widget class="QCheckBox" name="updateCheckBox">
                  <property name="sizePolicy">
@@ -940,6 +832,76 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="chooseHomeTabGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Default tab when opening settings</string>
+              </property>
+              <layout class="QVBoxLayout" name="tabSettingsLayout">
+               <item>
+                <widget class="QComboBox" name="chooseHomeTabComboBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>General</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Frontend</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Graphics</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>User</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Input</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Paths</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Log</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Debug</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Experimental</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_5">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>
@@ -972,7 +934,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>503</height>
+         <height>505</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1336,7 +1298,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>503</height>
+         <height>505</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1603,7 +1565,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>503</height>
+         <height>505</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0">
@@ -1889,7 +1851,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>503</height>
+         <height>505</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">


### PR DESCRIPTION
Since the choose home tab setting is no longer game-specific, it can be moved to the frontend settings tab instead. This effectively removes the setting from the game-specific GUI since frontend settings are not visible in the dialog when constructed as game-specific

<img width="966" height="794" alt="image" src="https://github.com/user-attachments/assets/c177ee66-cb9a-493c-b240-3809d2e461ce" />
