### PR TITLE
Min max deadzone

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -86,10 +86,14 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get,
         SetUIValuestoMappings();
     });
 
-    connect(ui->LeftDeadzoneSlider, &QSlider::valueChanged, this,
-            [this](int value) { ui->LeftDeadzoneValue->setText(QString::number(value)); });
-    connect(ui->RightDeadzoneSlider, &QSlider::valueChanged, this,
-            [this](int value) { ui->RightDeadzoneValue->setText(QString::number(value)); });
+    connect(ui->LeftDeadzoneMinSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->LeftDeadzoneMinValue->setText(QString::number(value)); });
+    connect(ui->LeftDeadzoneMaxSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->LeftDeadzoneMaxValue->setText(QString::number(value)); });
+    connect(ui->RightDeadzoneMinSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->RightDeadzoneMinValue->setText(QString::number(value)); });
+    connect(ui->RightDeadzoneMaxSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->RightDeadzoneMaxValue->setText(QString::number(value)); });
 
     connect(ui->RSlider, &QSlider::valueChanged, this, [this](int value) {
         QString RedValue = QString("%1").arg(value, 3, 10, QChar('0'));
@@ -283,11 +287,15 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     lines.push_back("");
     lines.push_back("# Range of deadzones: 1 (almost none) to 127 (max)");
 
-    std::string deadzonevalue = std::to_string(ui->LeftDeadzoneSlider->value());
-    lines.push_back("analog_deadzone = leftjoystick, " + deadzonevalue + ", 127");
+    std::string deadzone_min_value = std::to_string(ui->LeftDeadzoneMinSlider->value());
+    std::string deadzone_max_value = std::to_string(ui->LeftDeadzoneMaxSlider->value());
+    lines.push_back("analog_deadzone = leftjoystick, " + deadzone_min_value + ", " +
+                    deadzone_max_value);
 
-    deadzonevalue = std::to_string(ui->RightDeadzoneSlider->value());
-    lines.push_back("analog_deadzone = rightjoystick, " + deadzonevalue + ", 127");
+    deadzone_min_value = std::to_string(ui->RightDeadzoneMinSlider->value());
+    deadzone_max_value = std::to_string(ui->RightDeadzoneMaxSlider->value());
+    lines.push_back("analog_deadzone = rightjoystick, " + deadzone_min_value + ", " +
+                    deadzone_max_value);
 
     lines.push_back("");
     std::string OverrideLB = ui->LightbarCheckBox->isChecked() ? "true" : "false";
@@ -383,8 +391,10 @@ void ControlSettings::SetDefault() {
     ui->RStickLeftButton->setText("axis_right_x");
     ui->RStickRightButton->setText("axis_right_x");
 
-    ui->LeftDeadzoneSlider->setValue(2);
-    ui->RightDeadzoneSlider->setValue(2);
+    ui->LeftDeadzoneMinSlider->setValue(2);
+    ui->LeftDeadzoneMaxSlider->setValue(127);
+    ui->RightDeadzoneMinSlider->setValue(2);
+    ui->RightDeadzoneMaxSlider->setValue(127);
 
     ui->RSlider->setValue(0);
     ui->GSlider->setValue(0);
@@ -523,24 +533,41 @@ void ControlSettings::SetUIValuestoMappings() {
         if (input_string.contains("leftjoystick")) {
             std::size_t comma_pos = line.find(',');
             if (comma_pos != std::string::npos) {
-                int deadzonevalue = std::stoi(line.substr(comma_pos + 1));
-                ui->LeftDeadzoneSlider->setValue(deadzonevalue);
-                ui->LeftDeadzoneValue->setText(QString::number(deadzonevalue));
+                std::string deadzone_values = line.substr(comma_pos + 1);
+                std::size_t comma_pos2 = deadzone_values.find(',');
+                if (comma_pos2 != std::string::npos) {
+                    int deadzone_min_value = std::stoi(deadzone_values.substr(0, comma_pos2));
+                    int deadzone_max_value = std::stoi(deadzone_values.substr(comma_pos2 + 1));
+                    ui->LeftDeadzoneMinSlider->setValue(deadzone_min_value);
+                    ui->LeftDeadzoneMaxSlider->setValue(deadzone_max_value);
+                    ui->LeftDeadzoneMinValue->setText(QString::number(deadzone_min_value));
+                    ui->LeftDeadzoneMaxValue->setText(QString::number(deadzone_max_value));
+                }
             } else {
-                ui->LeftDeadzoneSlider->setValue(2);
-                ui->LeftDeadzoneValue->setText("2");
+                ui->LeftDeadzoneMinSlider->setValue(2);
+                ui->LeftDeadzoneMaxSlider->setValue(127);
+                ui->LeftDeadzoneMinValue->setText("2");
+                ui->LeftDeadzoneMaxValue->setText("127");
             }
         }
 
         if (input_string.contains("rightjoystick")) {
             std::size_t comma_pos = line.find(',');
             if (comma_pos != std::string::npos) {
-                int deadzonevalue = std::stoi(line.substr(comma_pos + 1));
-                ui->RightDeadzoneSlider->setValue(deadzonevalue);
-                ui->RightDeadzoneValue->setText(QString::number(deadzonevalue));
+                std::string deadzone_values = line.substr(comma_pos + 1);
+                std::size_t comma_pos2 = deadzone_values.find(',');
+                if (comma_pos2 != std::string::npos) {
+                    int deadzone_min_value = std::stoi(deadzone_values.substr(0, comma_pos2));
+                    int deadzone_max_value = std::stoi(deadzone_values.substr(comma_pos2 + 1));
+                    ui->RightDeadzoneMinSlider->setValue(deadzone_min_value);
+                    ui->RightDeadzoneMaxSlider->setValue(deadzone_max_value);
+                    ui->RightDeadzoneMinValue->setText(QString::number(deadzone_min_value));
+                    ui->RightDeadzoneMaxValue->setText(QString::number(deadzone_max_value));
             } else {
-                ui->RightDeadzoneSlider->setValue(2);
-                ui->RightDeadzoneValue->setText("2");
+                ui->RightDeadzoneMinSlider->setValue(2);
+                ui->RightDeadzoneMaxSlider->setValue(127);
+                ui->RightDeadzoneMinValue->setText("2");
+                ui->RightDeadzoneMaxValue->setText("127");
             }
         }
 

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -563,6 +563,7 @@ void ControlSettings::SetUIValuestoMappings() {
                     ui->RightDeadzoneMaxSlider->setValue(deadzone_max_value);
                     ui->RightDeadzoneMinValue->setText(QString::number(deadzone_min_value));
                     ui->RightDeadzoneMaxValue->setText(QString::number(deadzone_max_value));
+                }
             } else {
                 ui->RightDeadzoneMinSlider->setValue(2);
                 ui->RightDeadzoneMaxSlider->setValue(127);

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -357,11 +357,21 @@
              </sizepolicy>
             </property>
             <property name="title">
-             <string>Left Stick Deadzone (def:2 max:127)</string>
+             <string>Left Stick Deadzone</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_15">
              <item>
-              <widget class="QLabel" name="LeftDeadzoneValue">
+              <widget class="QLabel" name="LeftDeadzoneMinLabel">
+               <property name="text">
+                <string>Min Deadzone (def:2 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMinValue">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -369,7 +379,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Left Deadzone</string>
+                <string>2</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -377,7 +387,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="LeftDeadzoneSlider">
+              <widget class="QSlider" name="LeftDeadzoneMinSlider">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -388,6 +398,57 @@
                 <number>1</number>
                </property>
                <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMaxLabel">
+               <property name="text">
+                <string>Max Deadzone (def:127 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMaxValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>127</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="LeftDeadzoneMaxSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
                 <number>127</number>
                </property>
                <property name="orientation">
@@ -1546,11 +1607,21 @@
              </sizepolicy>
             </property>
             <property name="title">
-             <string>Right Stick Deadzone (def:2, max:127)</string>
+             <string>Right Stick Deadzone</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_13">
              <item>
-              <widget class="QLabel" name="RightDeadzoneValue">
+              <widget class="QLabel" name="RightDeadzoneMinLabel">
+               <property name="text">
+                <string>Min Deadzone (def:2 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMinValue">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -1558,7 +1629,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Right Deadzone</string>
+                <string>2</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1566,7 +1637,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="RightDeadzoneSlider">
+              <widget class="QSlider" name="RightDeadzoneMinSlider">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -1577,6 +1648,57 @@
                 <number>1</number>
                </property>
                <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMaxLabel">
+               <property name="text">
+                <string>Max Deadzone (def:127 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMaxValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>127</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="RightDeadzoneMaxSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
                 <number>127</number>
                </property>
                <property name="orientation">


### PR DESCRIPTION
Noticed that deadzone settings only has minimum distance toggle in ui. This pr adds maximum distance option to ui.
(once again, hi shadow)

<img width="1112" height="865" alt="Untitled" src="https://github.com/user-attachments/assets/fffbd57c-b905-4e10-9ff7-9a9544df4fa5" />
