### PR TITLE
Add checks before opening a new compatibility report based on the log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,8 @@ set(COMMON src/common/logging/backend.cpp
            src/common/logging/text_formatter.cpp
            src/common/logging/text_formatter.h
            src/common/logging/types.h
+           src/common/log_analyzer.cpp
+           src/common/log_analyzer.h
            src/common/aes.h
            src/common/assert.cpp
            src/common/assert.h

--- a/src/common/log_analyzer.cpp
+++ b/src/common/log_analyzer.cpp
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <fstream>
+#include <memory>
+#include "log_analyzer.h"
+#include "logging/log.h"
+
+namespace LogAnalyzer {
+
+std::vector<std::unique_ptr<Entry>> entries;
+
+inline std::string trim(const std::string& str) {
+    auto start = std::ranges::find_if_not(str.begin(), str.end(),
+                                          [](unsigned char c) { return std::isspace(c); });
+    auto end = std::ranges::find_if_not(str.rbegin(), str.rend(), [](unsigned char c) {
+                   return std::isspace(c);
+               }).base();
+    return (start < end) ? std::string(start, end) : std::string();
+}
+
+void LoadSuiteFromInput(std::istream& data) {
+    entry_id_counter = 1;
+    std::string line;
+
+    while (std::getline(data, line)) {
+        std::string type, pattern, description = "";
+        std::optional<string> label = std::nullopt, match_var_name = std::nullopt;
+        std::optional<bool> multiple = std::nullopt, silent_pass = std::nullopt,
+                            requirement = std::nullopt;
+        if (line.empty() || line[0] != '#')
+            continue;
+
+        std::istringstream iss(line.substr(1));
+        std::getline(iss, type, ',');
+        std::string params;
+        while (std::getline(iss, params, ',')) {
+            std::string p = trim(params);
+            if (p == "multiple")
+                multiple = true;
+            else if (p == "singular")
+                multiple = false;
+            else if (p == "silentpass")
+                silent_pass = true;
+            else if (p == "alwaysprint")
+                silent_pass = false;
+            else if (p == "requirement")
+                requirement = true;
+            else if (p == "optional")
+                requirement = false;
+        }
+        if (*type.rbegin() == ',')
+            type = type.substr(0, type.size() - 1);
+
+        if (!std::getline(data, line))
+            break;
+
+        if (line[0] == '-') {
+            description = line.substr(1);
+            if (!std::getline(data, line))
+                break;
+        }
+        if (line[0] == ';') {
+            label = line.substr(1);
+            if (!std::getline(data, line))
+                break;
+        }
+        if (line[0] == ':') {
+            match_var_name = line.substr(1);
+            if (!std::getline(data, line))
+                break;
+        }
+        pattern = line;
+
+        if (type == "MatchValueEntry") {
+            std::vector<std::string> accepted_values;
+            if (std::getline(data, line)) {
+                std::istringstream values(line);
+                std::string value;
+                while (std::getline(values, value, ',')) {
+                    if (!std::all_of(value.begin(), value.end(), isspace))
+                        accepted_values.push_back(value);
+                }
+            }
+            entries.push_back(std::make_unique<MatchValueEntry>(
+                pattern, description, label, match_var_name, accepted_values, multiple, requirement,
+                silent_pass));
+        } else if (type == "ShouldExistEntry") {
+            entries.push_back(std::make_unique<ShouldExistEntry>(
+                pattern, description, label, match_var_name, multiple, requirement, silent_pass));
+        } else if (type == "ShouldntExistEntry") {
+            entries.push_back(std::make_unique<ShouldntExistEntry>(
+                pattern, description, label, match_var_name, multiple, requirement, silent_pass));
+        } else {
+            entries.push_back(std::make_unique<Entry>(pattern, description, label, match_var_name,
+                                                      multiple, requirement, silent_pass));
+        }
+    }
+}
+
+void ResetEntries() {
+    for (auto& e : entries) {
+        e->Reset();
+    }
+}
+
+bool DetectLogTypeAndSetupEntries(std::string path) {
+    entries.clear();
+    enum LogType {
+        Release,
+        Nightly,
+        Old,
+    };
+    LogType type;
+    std::ifstream log(path);
+    if (!log.is_open()) {
+        LOG_ERROR(Log, "Invalid file path!");
+        return false;
+    }
+    bool is_valid = false;
+    std::string first_line;
+    std::getline(log, first_line);
+    first_line = trim(first_line);
+    Entry version_test =
+        Entry("[Loader] <Info> emulator.cpp:# Run: Starting shadps4 emulator +", "", "");
+    version_test.ProcessLine(first_line);
+    if (version_test.occurrence_count == 1) {
+        type = version_test.parsed_data[0].contains("WIP") ? Nightly : Release;
+    } else {
+        version_test = Entry("[Loader] <Info> emulator.cpp:# Starting shadps4 emulator +", "", "");
+        version_test.ProcessLine(first_line);
+        if (version_test.occurrence_count != 1) {
+            // likely not a shadPS4 log file at all, or log filters were used
+            is_valid = false;
+        }
+        type = Old;
+    }
+
+    std::string suite_path;
+    switch (type) {
+    case Release:
+    case Nightly:
+        is_valid = true;
+        break;
+    case Old:
+    default:
+        // todo maybe differentiate between these?
+        break;
+    }
+    if (!is_valid) {
+        return false;
+    }
+    std::istringstream ds(is_valid_report_suite);
+    LoadSuiteFromInput(ds);
+    return true;
+}
+
+bool ProcessFile(const std::string& path) {
+    bool is_valid_file = DetectLogTypeAndSetupEntries(path);
+    std::ifstream log(path);
+    std::string linebuf;
+    if (log.is_open()) {
+        while (std::getline(log, linebuf)) {
+            linebuf = trim(linebuf);
+            for (auto& entry : entries) {
+                entry->ProcessLine(linebuf);
+            }
+        }
+        log.close();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+optional<string> CheckResults(std::string game_id) {
+    if (!(entries[0]->GetParsedData().has_value() && *entries[0]->GetParsedData() == game_id)) {
+        return entries[0]->description;
+    }
+    if (!(entries[1]->GetParsedData().has_value() &&
+          !entries[1]->GetParsedData()->contains("WIP"))) {
+        return entries[1]->description;
+    }
+
+    for (int i = 2; i < entries.size(); ++i) {
+        if (!entries[1]->Passed()) {
+            return entries[i]->description;
+        }
+    }
+    return nullopt;
+}
+
+} // namespace LogAnalyzer

--- a/src/common/log_analyzer.h
+++ b/src/common/log_analyzer.h
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <optional>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace LogAnalyzer {
+
+using std::nullopt;
+using std::optional;
+using std::string;
+
+inline constexpr const char* is_valid_report_suite = R"(
+#Entry
+-The game ID in the log does not match the game ID of the selected game.
+[Loader] <Info> emulator.cpp:# Run: Game id: @ Title: *
+#Entry
+-The emulator version wasn't the latest release.
+[Loader] <Info> emulator.cpp:# Run: Starting shadps4 emulator +
+
+#MatchValueEntry
+-The emulator version wasn't the latest release.
+[Loader] <Info> emulator.cpp:# Run: Remote https://github.com/@(/)*
+shadps4-emu
+#MatchValueEntry
+-The log type was not snyc.
+[Config] <Info> emulator.cpp:# Run: General LogType: @
+sync
+#MatchValueEntry
+-PS4 Neo mode was turned on.
+[Config] <Info> emulator.cpp:# Run: General isNeo: @
+false
+
+#ShouldntExistEntry
+-isDevKit was turned on.
+[Kernel.Vmm] <Warning> memory.cpp:# SetupMemoryRegions: Config::isDevKitConsole is enabled! *
+#ShouldntExistEntry
+-System modules are missing.
+[Loader] <Info> emulator.cpp:# LoadSystemModules: No HLE available for @{ module}
+#ShouldntExistEntry
+-System modules are missing.
+[Loader] <Info> emulator.cpp:# LoadSystemModules: Can't Load @{ switching to HLE}
+#ShouldntExistEntry
+-Patches were used.
+[Loader] <Info> memory_patcher.cpp:# PatchMemory: Applied patch: *
+)";
+
+inline int entry_id_counter = 1;
+class Entry {
+public:
+    string pattern, description, label;
+    std::optional<string> variable_name;
+    int occurrence_count;
+    std::vector<string> parsed_data;
+    bool is_multiple_occurrence, counts_to_total, silent_pass;
+    int id;
+    size_t minimum_line_length;
+
+    Entry(string p, string d, optional<string> l = nullopt, optional<string> v = nullopt,
+          optional<bool> m = nullopt, optional<bool> c = nullopt, optional<bool> s = nullopt)
+        : pattern(p), description(d.size() != 0 ? d : p), label(l.value_or("")), variable_name(v),
+          occurrence_count(0), is_multiple_occurrence(m.value_or(false)),
+          counts_to_total(c.value_or(false)), silent_pass(s.value_or(true)), id(entry_id_counter++),
+          minimum_line_length(
+              p.size() -
+              std::min(p.size() < 2
+                           ? p.size()
+                           : (size_t)std::ranges::count_if(
+                                 std::views::iota(size_t{0}, std::max(p.size() - 2, size_t{0})),
+                                 [&p](size_t i) { return p[i] == '@' && p[i + 1] == '('; }) *
+                                 3,
+                       p.size())) {}
+    virtual ~Entry() = default;
+
+    virtual void ProcessLine(const std::string& line) {
+        if ((!is_multiple_occurrence && occurrence_count != 0) ||
+            line.size() < minimum_line_length) {
+            return;
+        }
+        auto line_it = line.begin();
+        auto pattern_it = pattern.begin();
+        std::stringstream in("");
+        int chars_to_discard = 0;
+        while (pattern_it != pattern.end()) {
+            if (*pattern_it == '#') {
+                while (line_it != line.end() && *line_it != ' ') {
+                    line_it++;
+                }
+            } else if (*pattern_it == '@') {
+                if (in.str().size() != 0) {
+                    in << " ";
+                }
+                if (pattern_it + 1 != pattern.end() && *(pattern_it + 1) == '{') {
+                    while (*pattern_it != '}') {
+                        chars_to_discard++;
+                        pattern_it++;
+                    }
+                    chars_to_discard -= 2;
+                    while (line_it != line.end() && (*line_it != ' ' || chars_to_discard != 0)) {
+                        in << *line_it++;
+                    }
+                } else if (pattern_it + 1 != pattern.end() && *(pattern_it + 1) == '(') {
+                    char discard_symbol = *(pattern_it + 2);
+                    while (line_it != line.end() && *line_it != discard_symbol) {
+                        in << *line_it++;
+                    }
+                    pattern_it += 3;
+                } else {
+                    while (line_it != line.end() && (*line_it != ' ' || chars_to_discard != 0)) {
+                        in << *line_it++;
+                    }
+                }
+            } else if (*pattern_it == '*') {
+                // break early as hitting this means that everything before was
+                // correct and everything after we don't care about
+                occurrence_count++;
+                if (in.str().size() > 0)
+                    parsed_data.push_back(in.str().substr(0, in.str().size() - chars_to_discard));
+                return;
+            } else if (*pattern_it == '+') {
+                if (in.str().size() != 0) {
+                    in << " ";
+                }
+                occurrence_count++;
+                in << string(line_it, line.end());
+                parsed_data.push_back(in.str().substr(0, in.str().size() - chars_to_discard));
+                return;
+            } else {
+                if (line_it == line.end() || *pattern_it != *line_it++) {
+                    return;
+                }
+            }
+            pattern_it++;
+        }
+        if (line_it == line.end()) {
+            if (in.str().size() > 0) {
+                if (chars_to_discard > 0) {
+                    // check if the discarded part actually fits
+                    auto rev_line_it = line.rbegin();
+                    auto rev_pattern_it = pattern.rbegin() + 1;
+                    while (*rev_pattern_it != '{') {
+                        if (*rev_pattern_it++ != *rev_line_it++) {
+                            return;
+                        }
+                    }
+                }
+                parsed_data.push_back(in.str().substr(0, in.str().size() - chars_to_discard));
+            }
+            occurrence_count++;
+        }
+    }
+    virtual void Reset() {
+        parsed_data.clear();
+        occurrence_count = 0;
+    }
+    virtual bool Passed() {
+        return true;
+    }
+    virtual std::optional<string> GetParsedData() {
+        if (parsed_data.size() > 0) {
+            return parsed_data[0];
+        }
+        return nullopt;
+    }
+};
+
+class MatchValueEntry : public Entry {
+public:
+    std::vector<string> accepted_data;
+    MatchValueEntry(string p, string d, optional<string> l, optional<string> v,
+                    std::vector<string> a, optional<bool> m = nullopt, optional<bool> c = nullopt,
+                    optional<bool> s = nullopt)
+        : Entry(p, d, l, v, m, c.value_or(true), s.value_or(true)), accepted_data(std::move(a)) {}
+    bool Passed() {
+        return occurrence_count != 0 &&
+               std::ranges::find(accepted_data.begin(), accepted_data.end(), parsed_data[0]) !=
+                   accepted_data.end();
+    }
+    optional<string> GetFirstAcceptedValue() {
+        if (accepted_data.size() == 0) {
+            return nullopt;
+        }
+        return accepted_data[0];
+    }
+};
+
+class ShouldExistEntry : public Entry {
+public:
+    ShouldExistEntry(string p, string d, optional<string> l = nullopt, optional<string> v = nullopt,
+                     optional<bool> m = nullopt, optional<bool> c = nullopt,
+                     optional<bool> s = nullopt)
+        : Entry(p, d, l, v, m, c.value_or(true), s.value_or(true)) {}
+    bool Passed() {
+        return occurrence_count != 0;
+    }
+};
+class ShouldntExistEntry : public Entry {
+public:
+    ShouldntExistEntry(string p, string d, optional<string> l = nullopt,
+                       optional<string> v = nullopt, optional<bool> m = nullopt,
+                       optional<bool> c = nullopt, optional<bool> s = nullopt)
+        : Entry(p, d, l, v, m, c.value_or(true), s.value_or(true)) {}
+    bool Passed() {
+        return occurrence_count == 0;
+    }
+};
+
+extern std::vector<std::unique_ptr<Entry>> entries;
+
+bool ProcessFile(const std::string& path);
+optional<string> CheckResults(std::string game_id);
+
+} // namespace LogAnalyzer

--- a/src/common/log_analyzer.h
+++ b/src/common/log_analyzer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <optional>
 #include <ranges>
@@ -18,16 +19,16 @@ using std::nullopt;
 using std::optional;
 using std::string;
 
-inline constexpr const char* is_valid_report_suite = R"(
+static inline constexpr char const* const is_valid_report_suite = R"(
 #Entry
 -The game ID in the log does not match the game ID of the selected game.
 [Loader] <Info> emulator.cpp:# Run: Game id: @ Title: *
 #Entry
--The emulator version wasn't the latest release.
+-The emulator version wasn't an official release one.
 [Loader] <Info> emulator.cpp:# Run: Starting shadps4 emulator +
 
 #MatchValueEntry
--The emulator version wasn't the latest release.
+-The emulator version wasn't an official release one.
 [Loader] <Info> emulator.cpp:# Run: Remote https://github.com/@(/)*
 shadps4-emu
 #MatchValueEntry
@@ -43,10 +44,10 @@ false
 -isDevKit was turned on.
 [Kernel.Vmm] <Warning> memory.cpp:# SetupMemoryRegions: Config::isDevKitConsole is enabled! *
 #ShouldntExistEntry
--System modules are missing.
+-System modules were missing.
 [Loader] <Info> emulator.cpp:# LoadSystemModules: No HLE available for @{ module}
 #ShouldntExistEntry
--System modules are missing.
+-System modules were missing.
 [Loader] <Info> emulator.cpp:# LoadSystemModules: Can't Load @{ switching to HLE}
 #ShouldntExistEntry
 -Patches were used.
@@ -80,7 +81,7 @@ public:
                        p.size())) {}
     virtual ~Entry() = default;
 
-    virtual void ProcessLine(const std::string& line) {
+    virtual void ProcessLine(std::string const& line) {
         if ((!is_multiple_occurrence && occurrence_count != 0) ||
             line.size() < minimum_line_length) {
             return;
@@ -215,7 +216,7 @@ public:
 
 extern std::vector<std::unique_ptr<Entry>> entries;
 
-bool ProcessFile(const std::string& path);
-optional<string> CheckResults(std::string game_id);
+bool ProcessFile(std::filesystem::path const& path);
+optional<string> CheckResults(std::string const& game_id);
 
 } // namespace LogAnalyzer

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -580,7 +580,7 @@ public:
             std::string log_file_path =
                 (Common::FS::GetUserPath(Common::FS::PathType::LogDir) /
                  (Config::getSeparateLogFilesEnabled() ? m_games[itemID].serial + ".log"
-                                                       : "shad_log.txt"));
+                                                       : "shad_log.txt")).c_str();
             bool is_valid_file = LogAnalyzer::ProcessFile(log_file_path);
             auto report_result = LogAnalyzer::CheckResults(m_games[itemID].serial);
             if (!is_valid_file || report_result.has_value()) {

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -1024,7 +1024,7 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
         }
     });
 
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [=, this]() {
         if (reply->error() != QNetworkReply::NoError) {
             QMessageBox::warning(this, tr("Error"),
                                  tr("Network error while downloading") + ":\n" +
@@ -1112,7 +1112,7 @@ void VersionDialog::showDownloadDialog(const QString& tagName, const QString& do
 #endif
             QProcess::startDetached(process, args);
 
-            QTimer::singleShot(4000, this, [=]() {
+            QTimer::singleShot(4000, this, [=, this]() {
                 progressBar->setValue(100);
                 dlg->close();
                 dlg->deleteLater();


### PR DESCRIPTION
This PR adds local checks for creating a compatibility report, and will only allow creating one from the GUI if all checks are passed. (Of course, one can still open an invalid report manually, that's not something that one can really do anything about.) In the event that one or more checks pass, an error popup is displayed with the first failed check's description, and a link to the compatibility list rules (the Info button). Before it gets merged, it should be tested first, as I'm sure there will be quite a few edge cases I haven't accounted for yet.
<img width="500" height="143" alt="image" src="https://github.com/user-attachments/assets/a564fe3f-fc19-44d8-b54a-667ed86345a5" />
