### PR TITLE
Add CLI interface to boot a specified emulator core directly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,10 @@
 // Custom message handler to ignore Qt logs
 void customMessageHandler(QtMsgType, const QMessageLogContext&, const QString&) {}
 
+void StopProgram() {
+    exit(0);
+}
+
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
     SetConsoleOutputCP(CP_UTF8);
@@ -147,6 +151,9 @@ int main(int argc, char* argv[]) {
         if (!std::filesystem::exists(emulator_path)) {
             std::cerr << "Error: specified emulator name or path is not found.\n";
             return 1;
+        }
+        if (!show_gui) {
+            m_main_window->m_ipc_client->gameClosedFunc = StopProgram;
         }
         m_main_window->StartEmulatorExecutable(emulator_path, emulator_args);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@ int main(int argc, char* argv[]) {
                     "  No arguments: Opens the GUI.\n"
                     "  -e, --emulator <name|path>    Specify the emulator version/path you want to "
                     "use, or 'default' for using the version selected in the config.\n"
+                    "  -d                            Alias for '-e default'.\n"
                     " -- ...                         Parameters passed to the emulator core. "
                     "Needs to be at the end of the line, and everything after '--' is an "
                     "emulator argument.\n"
@@ -68,6 +69,11 @@ int main(int argc, char* argv[]) {
              }
          }},
         {"--emulator", [&](int& i) { arg_map["-e"](i); }},
+        {"-d",
+         [&](int&) {
+             emulator = "default";
+             has_emulator_argument = true;
+         }},
     };
 
     // Parse command-line arguments using the map
@@ -125,6 +131,10 @@ int main(int argc, char* argv[]) {
         std::filesystem::path emulator_path;
         if (std::filesystem::exists(emulator)) {
             emulator_path = emulator;
+        } else if (emulator == "default") {
+            gui_settings settings{};
+            emulator_path = *std::filesystem::directory_iterator(
+                settings.GetValue(gui::vm_versionSelected).toString().toStdString());
         } else {
             std::filesystem::path version_dir = user_dir / "versions";
             for (auto const& version : std::filesystem::directory_iterator(version_dir)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,11 +39,14 @@ int main(int argc, char* argv[]) {
     std::string emulator;
     QStringList emulator_args{};
 
+    // Ignore Qt logs
+    qInstallMessageHandler(customMessageHandler);
+
     // Map of argument strings to lambda functions
     std::unordered_map<std::string, std::function<void(int&)>> arg_map = {
         {"-h",
          [&](int&) {
-             std::cerr
+             std::cout
                  << "Usage: shadps4 [options]\n"
                     "Options:\n"
                     "  No arguments: Opens the GUI.\n"
@@ -54,7 +57,7 @@ int main(int argc, char* argv[]) {
                     "Needs to be at the end of the line, and everything after '--' is an "
                     "emulator argument.\n"
                     "  -s, --show-gui                Show the GUI.\n"
-                    "  -h, --help                    Display this help message\n";
+                    "  -h, --help                    Display this help message.\n";
              exit(0);
          }},
         {"--help", [&](int& i) { arg_map["-h"](i); }}, // Redirect --help to -h
@@ -115,9 +118,6 @@ int main(int argc, char* argv[]) {
         GameInstallDialog dlg;
         dlg.exec();
     }
-
-    // Ignore Qt logs
-    qInstallMessageHandler(customMessageHandler);
 
     Common::Log::Initialize("shadPS4Launcher.log");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
     std::unordered_map<std::string, std::function<void(int&)>> arg_map = {
         {"-h",
          [&](int&) {
-             std::cout
+             std::cerr
                  << "Usage: shadps4 [options]\n"
                     "Options:\n"
                     "  No arguments: Opens the GUI.\n"
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
             has_emulator_argument = true;
         } else if (std::string(argv[i]) == "--") {
             if (i + 1 == argc) {
-                std::cerr << "Warning: -- is set, but no game arguments are added!\n";
+                std::cerr << "Warning: -- is set, but no emulator arguments are added!\n";
                 break;
             }
             for (int j = i + 1; j < argc; j++) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1296,7 +1296,8 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
 
 void MainWindow::StartEmulatorExecutable(std::filesystem::path path, QStringList args) {
     if (Config::getGameRunning()) {
-        QMessageBox::critical(nullptr, tr("Run Emulator"), QString(tr("Emulator is already running!")));
+        QMessageBox::critical(nullptr, tr("Run Emulator"),
+                              QString(tr("Emulator is already running!")));
         return;
     }
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1309,15 +1309,9 @@ void MainWindow::StartEmulatorExecutable(std::filesystem::path path, QStringList
         return;
     }
 
-    QStringList final_args{"--game", QString::fromStdWString(path.wstring())};
-
-    final_args.append(args);
-
     QString workDir = QDir::currentPath();
 
-    LOG_INFO(IPC, "Starting emulator {} with arg {}", path.c_str(), args[0].toStdString());
-
-    m_ipc_client->startEmulator(fileInfo, final_args, workDir);
+    m_ipc_client->startEmulator(fileInfo, args, workDir);
     m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
 }
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1294,6 +1294,33 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
     m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
 }
 
+void MainWindow::StartEmulatorExecutable(std::filesystem::path path, QStringList args) {
+    if (Config::getGameRunning()) {
+        QMessageBox::critical(nullptr, tr("Run Emulator"), QString(tr("Emulator is already running!")));
+        return;
+    }
+
+    Config::setGameRunning(true);
+    QFileInfo fileInfo(path);
+    if (!fileInfo.exists()) {
+        QMessageBox::critical(nullptr, "shadPS4",
+                              QString(tr("Could not find the emulator executable")));
+        Config::setGameRunning(false);
+        return;
+    }
+
+    QStringList final_args{"--game", QString::fromStdWString(path.wstring())};
+
+    final_args.append(args);
+
+    QString workDir = QDir::currentPath();
+
+    LOG_INFO(IPC, "Starting emulator {} with arg {}", path.c_str(), args[0].toStdString());
+
+    m_ipc_client->startEmulator(fileInfo, final_args, workDir);
+    m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
+}
+
 void MainWindow::RunGame() {
     auto gameInfo = GameInfoClass();
     auto dir = last_game_path.parent_path();

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -35,6 +35,8 @@ public:
     void InstallDirectory();
     void StartGame();
     void StartGameWithArgs(QStringList args = {});
+    void StartEmulator(std::filesystem::path path, QStringList args = {});
+    void StartEmulatorExecutable(std::filesystem::path path, QStringList args = {});
     void PauseGame();
     void StopGame();
     void RestartGame();
@@ -77,7 +79,6 @@ private:
     void LoadTranslation();
     void PlayBackgroundMusic();
     QIcon RecolorIcon(const QIcon& icon, bool isWhite);
-    void StartEmulator(std::filesystem::path, QStringList args = {});
     void RestartEmulator();
 
     bool isIconBlack = false;

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -42,6 +42,7 @@ public:
     void RestartGame();
     void LoadVersionComboBox();
     bool showLabels;
+    std::shared_ptr<IpcClient> m_ipc_client = std::make_shared<IpcClient>();
 
 private Q_SLOTS:
     void ConfigureGuiFromSettings();
@@ -111,7 +112,6 @@ private:
     QTranslator* translator;
     std::shared_ptr<gui_settings> m_gui_settings;
 
-    std::shared_ptr<IpcClient> m_ipc_client = std::make_shared<IpcClient>();
     std::filesystem::path last_game_path;
 
 protected:


### PR DESCRIPTION
```
Options:
  No arguments: Opens the GUI.
  -e, --emulator <name|path>    Specify the emulator version/path you want to use, or 'default' for using the version selected in the config.
  -d                            Alias for '-e default'.
 -- ...                         Parameters passed to the emulator core. Needs to be at the end of the line, and everything after '--' is an emulator argument.
  -s, --show-gui                Show the GUI.
  -h, --help                    Display this help message
  ```
  Currently, 0.5.0 works, my local build works, but for some reason 0.11.0 is broken, and I don't know why.