### PR TITLE
Versions from config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,8 @@ set(COMMON src/common/logging/backend.cpp
            src/common/bounded_threadsafe_queue.h
            src/common/config.cpp
            src/common/config.h
+           src/common/versions.cpp
+           src/common/versions.h
            src/common/endian.h
            src/common/enum.h
            src/common/io_file.cpp

--- a/src/common/versions.cpp
+++ b/src/common/versions.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "versions.h"
+#include "logging/log.h"
+
+namespace VersionManager {
+
+std::vector<Version> GetVersionList(std::filesystem::path const& path) {
+    toml::ordered_value data;
+    try {
+        data = toml::parse(path);
+    } catch (std::exception& ex) {
+        fmt::print("Got exception trying to load config file. Exception: {}\n", ex.what());
+        return {};
+    }
+
+    std::vector<Version> versions;
+    for (const auto& [key, value] : data.as_table()) {
+        Version v;
+        v.name = toml::find_or<std::string>(value, "name", "no name");
+        v.path = toml::find_or<std::string>(value, "path", "");
+        v.date = toml::find_or<std::string>(value, "date", "never");
+        v.codename = toml::find_or<std::string>(value, "codename", "");
+        v.type = static_cast<VersionType>(toml::find_or<int>(value, "type", VersionType::Custom));
+        versions.push_back(std::move(v));
+    }
+
+    for (const auto& v : versions)
+        LOG_INFO(Core, "{} ({}): {}", v.name, (s32)v.type, v.path);
+    
+    return std::move(versions);
+}
+
+}

--- a/src/common/versions.cpp
+++ b/src/common/versions.cpp
@@ -1,15 +1,20 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "versions.h"
 #include "logging/log.h"
+#include "versions.h"
+#include "path_util.h"
 
 namespace VersionManager {
 
 std::vector<Version> GetVersionList(std::filesystem::path const& path) {
     toml::ordered_value data;
     try {
-        data = toml::parse(path);
+        if (path.empty()) {
+            data = toml::parse(Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "versions.toml");
+        } else {
+            data = toml::parse(path);
+        }
     } catch (std::exception& ex) {
         fmt::print("Got exception trying to load config file. Exception: {}\n", ex.what());
         return {};
@@ -26,10 +31,7 @@ std::vector<Version> GetVersionList(std::filesystem::path const& path) {
         versions.push_back(std::move(v));
     }
 
-    for (const auto& v : versions)
-        LOG_INFO(Core, "{} ({}): {}", v.name, (s32)v.type, v.path);
-    
     return std::move(versions);
 }
 
-}
+} // namespace VersionManager

--- a/src/common/versions.h
+++ b/src/common/versions.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <toml.hpp>
+
+namespace VersionManager {
+
+enum VersionType {
+    Release = 0,
+    Nightly = 1,
+    Custom = 2,
+};
+
+struct Version {
+    std::string name;
+    std::string path;
+    std::string date;
+    std::string codename;
+    VersionType type;
+};
+
+std::vector<Version> GetVersionList(std::filesystem::path const& path);
+
+}

--- a/src/common/versions.h
+++ b/src/common/versions.h
@@ -26,4 +26,6 @@ struct Version {
 
 std::vector<Version> GetVersionList(std::filesystem::path const& path = "");
 
+void AddNewVersion(Version const& v, std::filesystem::path const& path = "");
+
 }

--- a/src/common/versions.h
+++ b/src/common/versions.h
@@ -24,6 +24,6 @@ struct Version {
     VersionType type;
 };
 
-std::vector<Version> GetVersionList(std::filesystem::path const& path);
+std::vector<Version> GetVersionList(std::filesystem::path const& path = "");
 
 }

--- a/src/common/versions.h
+++ b/src/common/versions.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <vector>
-#include <filesystem>
 #include <toml.hpp>
 #include "types.h"
 
@@ -32,4 +32,4 @@ void AddNewVersion(Version const& v, std::filesystem::path const& path = "");
 void RemoveVersion(Version const& v, std::filesystem::path const& path = "");
 void RemoveVersion(std::string const& v, std::filesystem::path const& path = "");
 
-}
+} // namespace VersionManager

--- a/src/common/versions.h
+++ b/src/common/versions.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <filesystem>
 #include <toml.hpp>
+#include "types.h"
 
 namespace VersionManager {
 
@@ -22,10 +23,13 @@ struct Version {
     std::string date;
     std::string codename;
     VersionType type;
+    s32 id;
 };
 
 std::vector<Version> GetVersionList(std::filesystem::path const& path = "");
 
 void AddNewVersion(Version const& v, std::filesystem::path const& path = "");
+void RemoveVersion(Version const& v, std::filesystem::path const& path = "");
+void RemoveVersion(std::string const& v, std::filesystem::path const& path = "");
 
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1269,16 +1269,7 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
     Config::setGameRunning(true);
     last_game_path = path;
 
-    QString exeName;
-#ifdef Q_OS_WIN
-    exeName = "/shadPS4.exe";
-#elif defined(Q_OS_LINUX)
-    exeName = "/Shadps4-sdl.AppImage";
-#elif defined(Q_OS_MACOS)
-    exeName = "/shadps4";
-#endif
-    QString exe = selectedVersion + exeName;
-    QFileInfo fileInfo(exe);
+    QFileInfo fileInfo(selectedVersion);
     if (!fileInfo.exists()) {
         QMessageBox::critical(nullptr, "shadPS4",
                               QString(tr("Could not find the emulator executable")));

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -17,9 +17,9 @@
 #endif
 #include "common/logging/log.h"
 #include "common/memory_patcher.h"
-#include "common/versions.h"
 #include "common/path_util.h"
 #include "common/scm_rev.h"
+#include "common/versions.h"
 #include "control_settings.h"
 #include "game_install_dialog.h"
 #include "hotkeys.h"
@@ -1361,7 +1361,8 @@ void MainWindow::LoadVersionComboBox() {
 
     auto const& versions = VersionManager::GetVersionList();
     for (auto const& v : versions) {
-        ui->versionComboBox->addItem(QString::fromStdString(v.name), QString::fromStdString(v.path));
+        ui->versionComboBox->addItem(QString::fromStdString(v.name),
+                                     QString::fromStdString(v.path));
     }
 
     int selectedIndex = ui->versionComboBox->findData(savedVersionPath);

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -516,7 +516,7 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                         this, tr("Confirm Download"),
                                         tr("Version %1 has been downloaded and selected.")
                                             .arg(versionName));
-                                    bool is_release = versionName.contains("Pre-release");
+                                    bool is_release = !versionName.contains("Pre-release");
                                     auto release_name = release["name"].toString();
                                     QString code_name = "";
                                     static constexpr QStringView marker = u" - codename ";

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -538,7 +538,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                         .type = is_release ? VersionManager::VersionType::Release
                                                            : VersionManager::VersionType::Nightly,
                                     };
-                                    m_gui_settings->SetValue(gui::vm_versionSelected, QString(exe_path.c_str()));
+                                    m_gui_settings->SetValue(gui::vm_versionSelected,
+                                                             QString(exe_path.c_str()));
                                     VersionManager::AddNewVersion(new_version);
                                     LoadInstalledList();
                                 });

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -112,7 +112,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
         version_name = version_name.trimmed();
 
         if (std::find_if(version_list.cbegin(), version_list.cend(), [version_name](auto i) {
-                return i.name == version_name;
+                return i.name == version_name.toStdString();
             }) != version_list.cend()) {
             QMessageBox::warning(this, tr("Error"), tr("A version with that name already exists."));
             return;

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -529,7 +529,7 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                             fullPath.toStdString()};
                                     VersionManager::Version new_version{
                                         .name = versionName.toStdString(),
-                                        .path = exe_path,
+                                        .path = exe_path.generic_string(),
                                         .date = release["published_at"]
                                                     .toString()
                                                     .left(10)

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -551,7 +551,7 @@ void VersionDialog::LoadInstalledList() {
 
     const auto path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "versions.toml";
     auto versions = VersionManager::GetVersionList(path);
-
+    auto const& selected_version = m_gui_settings->GetValue(gui::vm_versionSelected).toString().toStdString();
 
     ui->installedTreeWidget->clear();
     ui->installedTreeWidget->setColumnCount(5);
@@ -563,8 +563,7 @@ void VersionDialog::LoadInstalledList() {
         item->setText(2, QString::fromStdString(v.codename));
         item->setText(3, QString::fromStdString(v.date));
         item->setText(4, QString::fromStdString(v.path));
-        item->setCheckState(0, Qt::Unchecked);
-
+        item->setCheckState(0, (selected_version == v.path) ? Qt::Checked : Qt::Unchecked);
     }
 
     // QStringList folders = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);


### PR DESCRIPTION
This PR rewrites the version manager to depend on a config file, instead of the filesystem. This comes with the benefit of being able to boot any build, including locally built ones, that are not in the user folder's versions directory, and also simplifies the logic in some places.

Things that are done:
- Version selector combo box
- Main version manager list
- Downloading releases
- Adding local builds
- Removing entries from the list

Things that are not done:
- Updating a pre-release isn't handled correctly
- Currently, removing a version just removes the entry from the list, but doesn't actually delete any files
- Anything that should have been mentioned to have been updated, but hasn't

