### PR TITLE
Install qt 6.10.0 on linux runner

### DIFF
--- a/.github/linux-appimage-qt.sh
+++ b/.github/linux-appimage-qt.sh
@@ -10,6 +10,7 @@ fi
 export Qt6_DIR="/usr/lib/qt6"
 export PATH="$Qt6_DIR/bin:$PATH"
 export EXTRA_QT_PLUGINS="waylandcompositor"
+export EXTRA_PLATFORM_PLUGINS="libqwayland.so"
 
 # Prepare Tools for building the AppImage
 wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage

--- a/.github/linux-appimage-qt.sh
+++ b/.github/linux-appimage-qt.sh
@@ -10,7 +10,6 @@ fi
 export Qt6_DIR="/usr/lib/qt6"
 export PATH="$Qt6_DIR/bin:$PATH"
 export EXTRA_QT_PLUGINS="waylandcompositor"
-export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
 
 # Prepare Tools for building the AppImage
 wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10
+        version: 6.10.0
         host: windows
         target: desktop
         arch: win64_msvc2022_64
@@ -141,7 +141,7 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10
+        version: 6.10.0
         host: mac
         target: desktop
         arch: clang_64
@@ -210,7 +210,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.10
+        version: 6.10.0
         arch: linux_gcc_64
         modules: "qtmultimedia"
         tools: 'tools_generic'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.9.3
+        version: 6.10
         host: windows
         target: desktop
         arch: win64_msvc2022_64
@@ -141,7 +141,7 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.9.3
+        version: 6.10
         host: mac
         target: desktop
         arch: clang_64
@@ -210,7 +210,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.9.3
+        version: 6.10
         arch: linux_gcc_64
         modules: "qtmultimedia"
         tools: 'tools_generic'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,16 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang-19 mold build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
 
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.9.3
+        arch: linux_gcc_64
+        modules: "qtnetworkauth"
+        tools: 'tools_opensslv3_src'
+        setup-python: false
+        cache: true
+
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,15 +205,15 @@ jobs:
         sudo add-apt-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main'
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang-19 mold build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang-19 mold build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
         version: 6.9.3
         arch: linux_gcc_64
-        modules: "qtnetworkauth"
-        tools: 'tools_opensslv3_src'
+        modules: "qtmultimedia"
+        tools: 'tools_generic'
         setup-python: false
         cache: true
 


### PR DESCRIPTION
Popping in because I realized this can be done.

Since we were using an older qt version for linux, there need to be some #if (qtversion < something) in the code only for linux version which are kinda annoying, and this should make those unnecessary.

Also spacers work differently in the old version. When on the correct version they work as intended,

Main:
<img width="962" height="794" alt="image" src="https://github.com/user-attachments/assets/aa8d0d89-9728-41f8-bac8-01006dcdab6b" />

<img width="960" height="801" alt="image" src="https://github.com/user-attachments/assets/b89f3c85-71ec-45b7-b270-ff5eeed752ee" />


PR:
<img width="965" height="800" alt="image" src="https://github.com/user-attachments/assets/5a4fe5f3-885a-4495-95a5-9d783287df14" />

<img width="965" height="800" alt="image" src="https://github.com/user-attachments/assets/08c1716b-5498-43db-a99c-6d5755638c22" />

Not sure if this can break anything, don't have time to test. Also not sure what the qt-tools module is used for, and if it's the same as the tools-generic module in linux aqt, but that seems to be most logical thing to replace it