### PR TITLE
Sizing changes for the version manager

### DIFF
--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -28,6 +28,7 @@
 VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
     : QDialog(parent), ui(new Ui::VersionDialog), m_gui_settings(std::move(gui_settings)) {
     ui->setupUi(this);
+    this->setMinimumSize(670, 350);
 
     ui->checkOnStartupCheckBox->setChecked(
         m_gui_settings->GetValue(gui::vm_checkOnStartup).toBool());

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -39,6 +39,8 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
     connect(ui->showChangelogCheckBox, &QCheckBox::toggled, this,
             [this](bool checked) { m_gui_settings->SetValue(gui::vm_showChangeLog, checked); });
 
+    connect(this, &VersionDialog::WindowResized, this, &VersionDialog::HandleResize);
+
     networkManager = new QNetworkAccessManager(this);
 
     if (m_gui_settings->GetValue(gui::vm_versionPath).toString() == "") {
@@ -180,6 +182,15 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
 
 VersionDialog::~VersionDialog() {
     delete ui;
+}
+
+void VersionDialog::resizeEvent(QResizeEvent* event) {
+    emit WindowResized(event);
+    QDialog::resizeEvent(event);
+}
+
+void VersionDialog::HandleResize(QResizeEvent* event) {
+    this->ui->versionTab->resize(this->size());
 }
 
 void VersionDialog::onItemChanged(QTreeWidgetItem* item, int column) {

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -15,6 +15,8 @@ class VersionDialog;
 
 class VersionDialog : public QDialog {
     Q_OBJECT
+signals:
+    void WindowResized(QResizeEvent* event);
 
 public:
     explicit VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
@@ -23,6 +25,9 @@ public:
     void checkUpdatePre(const bool showMessage);
     void DownloadListVersion();
     void InstallSelectedVersion();
+
+private Q_SLOTS:
+    void HandleResize(QResizeEvent* event);
 
 private:
     Ui::VersionDialog* ui;
@@ -39,4 +44,7 @@ private:
                           const QString& latestTag, QTextBrowser* outputView);
     void installPreReleaseByTag(const QString& tagName);
     void showDownloadDialog(const QString& tagName, const QString& downloadUrl);
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
 };

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -8,7 +8,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
+    <width>800</width>
     <height>500</height>
    </rect>
   </property>
@@ -24,7 +24,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>700</width>
+     <width>800</width>
      <height>500</height>
     </rect>
    </property>


### PR DESCRIPTION
* Increase the starting width slightly because 700 cuts off the date of the installed versions list

* Set a minimum size

* Handle resize events so the versionTab QScrollArea resizes with the dialog

I'm still new to Qt so please let me know if I did anything wrong.
I just mimic what the MainWindow does.