### PR TITLE
Fix locating version executable on macOS.

### DIFF
--- a/src/qt_gui/create_shortcut.cpp
+++ b/src/qt_gui/create_shortcut.cpp
@@ -50,18 +50,9 @@ void ShortcutDialog::createShortcut() {
         return;
     }
 
-    QString versionFolder = m_gui_settings->GetValue(gui::vm_versionPath).toString();
-    QString versionName = "/" + listWidget->currentItem()->text();
-    QString exeName;
-#ifdef Q_OS_WIN
-    exeName = "/shadPS4.exe";
-#elif defined(Q_OS_LINUX)
-    exeName = "/Shadps4-sdl.AppImage";
-#elif defined(Q_OS_MACOS)
-    exeName = "/shadps4";
-#endif
-
-    emit shortcutRequested(versionFolder + versionName + exeName);
+    const QString selectedVersion = listWidget->currentItem()->text();
+    const QString executablePath = m_gui_settings->GetVersionExecutablePath(selectedVersion);
+    emit shortcutRequested(executablePath);
     QWidget::close();
 }
 

--- a/src/qt_gui/gui_settings.cpp
+++ b/src/qt_gui/gui_settings.cpp
@@ -1,9 +1,29 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/path_util.h"
 #include "gui_settings.h"
 
 gui_settings::gui_settings(QObject* parent) : settings(parent) {
     m_settings = std::make_unique<QSettings>(ComputeSettingsDir() + "qt_ui.ini",
                                              QSettings::Format::IniFormat, parent);
+}
+
+QString gui_settings::GetVersionExecutablePath(const QString& versionName) const {
+    const auto versionsFolder =
+        Common::FS::PathFromQString(GetValue(gui::vm_versionPath).toString());
+    const auto versionFolder = versionsFolder / Common::FS::PathFromQString(versionName);
+
+    std::string exeName;
+#ifdef Q_OS_WIN
+    exeName = "shadPS4.exe";
+#elif defined(Q_OS_LINUX)
+    exeName = "Shadps4-sdl.AppImage";
+#elif defined(Q_OS_MACOS)
+    exeName = "shadps4";
+#endif
+
+    QString result;
+    Common::FS::PathToQString(result, versionFolder / exeName);
+    return result;
 }

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -79,4 +79,6 @@ class gui_settings : public settings {
 public:
     explicit gui_settings(QObject* parent = nullptr);
     ~gui_settings() override = default;
+
+    QString GetVersionExecutablePath(const QString& versionName) const;
 };

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1266,9 +1266,6 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
         return;
     }
 
-    Config::setGameRunning(true);
-    last_game_path = path;
-
     QFileInfo fileInfo(selectedVersion);
     if (!fileInfo.exists()) {
         QMessageBox::critical(nullptr, "shadPS4",
@@ -1280,8 +1277,10 @@ tr("No emulator version was selected.\nThe Version Manager menu will then open.\
 
     final_args.append(args);
 
-    QString workDir = QDir::currentPath();
+    Config::setGameRunning(true);
+    last_game_path = path;
 
+    QString workDir = QDir::currentPath();
     m_ipc_client->startEmulator(fileInfo, final_args, workDir);
     m_ipc_client->setActiveController(GamepadSelect::GetSelectedGamepad());
 }

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -94,11 +94,11 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
         exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
                                                tr("Executable (*.exe)"));
 #elif defined(Q_OS_LINUX)
-    exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
-                                            "Executable (*)");
+        exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
+                                                "Executable (*)");
 #elif defined(Q_OS_MACOS)
-    exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
-                                            "Executable (*.*)");
+        exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
+                                                "Executable (*.*)");
 #endif
 
         if (exePath.isEmpty())
@@ -523,7 +523,8 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
 
                                     QString userPath =
                                         m_gui_settings->GetValue(gui::vm_versionPath).toString();
-                                    QString fullPath = QDir(userPath).filePath(folderName);
+                                    QString executablePath =
+                                        m_gui_settings->GetVersionExecutablePath(folderName);
 
                                     QMessageBox::information(
                                         this, tr("Confirm Download"),
@@ -538,8 +539,7 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                         code_name = release_name.mid(idx + marker.size());
                                     }
                                     std::filesystem::path exe_path =
-                                        *std::filesystem::directory_iterator{
-                                            fullPath.toStdString()};
+                                        Common::FS::PathFromQString(executablePath);
                                     VersionManager::Version new_version{
                                         .name = versionName.toStdString(),
                                         .path = exe_path.generic_string(),


### PR DESCRIPTION
On macOS the SDL distribution has multiple files to include the MoltenVK dylib and ICD file. The current version logic is picking the `libMoltenVK.dylib` file as the executable instead of the emulator itself, since it just uses the first entry in the directory iterator.

Instead, just commonize the existing working logic from creating shortcuts and use that.