### PR TITLE
Put logging into main window instead of a separate terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ cmrc_add_resource_library(embedded-resources
 target_link_libraries(shadPS4QtLauncher PRIVATE res::embedded)
 
 set_target_properties(shadPS4QtLauncher PROPERTIES
-#       WIN32_EXECUTABLE ON
+    WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/dist/MacOSBundleInfo.plist.in"
     MACOSX_BUNDLE_ICON_FILE "shadPS4.icns"

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -180,13 +180,11 @@ void IpcClient::onStderr() {
 
 void IpcClient::onStdout() {
     QColor color;
-    QString entry;
-
     QByteArray data = process->readAllStandardOutput();
     QString dataString = QString::fromUtf8(data);
-    QStringList lines = dataString.split('\n');
+    QStringList entries = dataString.split('\n');
 
-    for (QString& entry : lines) {
+    for (QString& entry : entries) {
         if (entry.contains("<Warning>")) {
             color = Qt::yellow;
         } else if (entry.contains("<Error>")) {

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -4,6 +4,7 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QProcessEnvironment>
+#include <QTextStream>
 
 #include "common/logging/log.h"
 #include "ipc_client.h"
@@ -178,7 +179,23 @@ void IpcClient::onStderr() {
 }
 
 void IpcClient::onStdout() {
-    printf("%s", process->readAllStandardOutput().toStdString().c_str());
+    QColor color;
+    QString entry;
+
+    while (process->canReadLine()) {
+        entry = process->readLine().trimmed();
+    }
+
+    // set log text color based on class
+    if (entry.contains("<Warning>")) {
+        color = Qt::yellow;
+    } else if (entry.contains("<Critical>") || entry.contains("<Error>")) {
+        color = Qt::red;
+    } else {
+        color = Qt::white;
+    }
+
+    emit LogEntrySent(entry, color);
 }
 
 void IpcClient::onProcessClosed() {

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -4,7 +4,7 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QProcessEnvironment>
-#include <QTextStream>
+#include <QRegularExpression>
 
 #include "common/logging/log.h"
 #include "ipc_client.h"
@@ -195,7 +195,8 @@ void IpcClient::onStdout() {
         color = Qt::white;
     }
 
-    emit LogEntrySent(entry, color);
+    QRegularExpression ansiRegex(R"(\x1B\[[0-9;]*[mK])"); // ANSI escape codes from UNIX terminals
+    emit LogEntrySent(entry.replace(ansiRegex, ""), color);
 }
 
 void IpcClient::onProcessClosed() {

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -201,9 +201,10 @@ void IpcClient::onStdout() {
 
         QRegularExpression ansiRegex(
             R"(\x1B\[[0-9;]*[mK])"); // ANSI escape codes from UNIX terminals
+        entry = entry.replace(ansiRegex, "");
 
         if (!entry.isEmpty())
-            emit LogEntrySent(entry.replace(ansiRegex, "").trimmed(), color);
+            emit LogEntrySent(entry.trimmed(), color);
     }
 }
 

--- a/src/ipc/ipc_client.cpp
+++ b/src/ipc/ipc_client.cpp
@@ -189,8 +189,14 @@ void IpcClient::onStdout() {
     // set log text color based on class
     if (entry.contains("<Warning>")) {
         color = Qt::yellow;
-    } else if (entry.contains("<Critical>") || entry.contains("<Error>")) {
+    } else if (entry.contains("<Error>")) {
         color = Qt::red;
+    } else if (entry.contains("<Critical>")) {
+        color = Qt::magenta;
+    } else if (entry.contains("<Trace>")) {
+        color = Qt::gray;
+    } else if (entry.contains("<Debug>")) {
+        color = Qt::cyan;
     } else {
         color = Qt::white;
     }

--- a/src/ipc/ipc_client.h
+++ b/src/ipc/ipc_client.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 
+#include <QColor>
 #include <QFileInfo>
 #include <QProcess>
 
@@ -12,6 +13,10 @@
 
 class IpcClient : public QObject {
     Q_OBJECT
+
+signals:
+    void LogEntrySent(QString entry, QColor textColor);
+
 public:
     explicit IpcClient(QObject* parent = nullptr);
     void startEmulator(const QFileInfo& exe, const QStringList& args,

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -33,6 +33,9 @@ const gui_value gen_homeTab = gui_value(general_settings, "homeTab", "General");
 // main window settings
 const gui_value mw_geometry = gui_value(main_window, "geometry", QByteArray());
 const gui_value mw_showLabelsUnderIcons = gui_value(main_window, "showLabelsUnderIcons", true);
+const gui_value mw_showLog = gui_value(main_window, "showLog", true);
+const gui_value mw_dockWidgetSizes =
+    gui_value(main_window, "dockWidgetSizes", QVariant::fromValue(QList<int>()));
 
 // game list settings
 const gui_value gl_mode = gui_value(game_list, "tableMode", 0);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -376,6 +376,10 @@ void MainWindow::CreateDockWindows(bool newDock) {
     }
 
     ui->splitter->setSizes({sizes});
+    ui->splitter->setCollapsible(0, false);
+    ui->splitter->setCollapsible(1, false);
+    ui->splitter->setCollapsible(2, false);
+
     dockLayout->addWidget(ui->splitter);
     dockContents->setLayout(dockLayout);
     m_dock_widget->setWidget(dockContents);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -362,8 +362,9 @@ void MainWindow::CreateDockWindows(bool newDock) {
         isTableList = false;
     }
 
-    ui->logDisplay->setStyleSheet("QTextEdit {background-color: black;}");
-    ui->logDisplay->setMinimumHeight(0);
+    QPalette logPalette = ui->logDisplay->palette();
+    logPalette.setColor(QPalette::Base, Qt::black);
+    ui->logDisplay->setPalette(logPalette);
 
     ui->splitter->addWidget(ui->logDisplay);
     ui->splitter->addWidget(ui->toggleLogButton);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -308,9 +308,9 @@ void MainWindow::CreateDockWindows() {
     QWidget* phCentralWidget = new QWidget(this);
     setCentralWidget(phCentralWidget);
 
+    QSplitter* splitter = new QSplitter(Qt::Vertical);
     QWidget* dockContents = new QWidget(this);
     QVBoxLayout* dockLayout = new QVBoxLayout(this);
-    QSplitter* splitter = new QSplitter(Qt::Vertical);
 
     m_dock_widget.reset(new QDockWidget(tr("Game List"), this));
     m_game_list_frame.reset(
@@ -354,19 +354,14 @@ void MainWindow::CreateDockWindows() {
     splitter->addWidget(ui->logDisplay);
     splitter->addWidget(ui->toggleLogButton);
 
-    QList<int> sizes = {400, 200, 50};
-    sizes = gui_settings::Var2IntList(m_gui_settings->GetValue(gui::mw_dockWidgetSizes));
-    splitter->setSizes({sizes});
-
-    bool showLog = m_gui_settings->GetValue(gui::mw_showLog).toBool();
-    if (showLog) {
-        ui->toggleLogButton->setText(tr("Hide Log"));
-        ui->logDisplay->show();
-    } else {
-        ui->toggleLogButton->setText(tr("Show Log"));
-        ui->logDisplay->hide();
+    QList<int> defaultSizes = {800, 200, 50}; // these are proportionally adjusted by qt
+    QList<int> sizes = gui_settings::Var2IntList(m_gui_settings->GetValue(
+        gui::main_window, "dockWidgetSizes", QVariant::fromValue(defaultSizes)));
+    if (sizes[1] == 0) { // This happens if log is hidden when settings are saved
+        sizes = defaultSizes;
     }
 
+    splitter->setSizes({sizes});
     dockLayout->addWidget(splitter);
     dockContents->setLayout(dockLayout);
     m_dock_widget->setWidget(dockContents);
@@ -377,6 +372,15 @@ void MainWindow::CreateDockWindows() {
 
     addDockWidget(Qt::LeftDockWidgetArea, m_dock_widget.data());
     this->setDockNestingEnabled(true);
+
+    bool showLog = m_gui_settings->GetValue(gui::mw_showLog).toBool();
+    if (showLog) {
+        ui->toggleLogButton->setText(tr("Hide Log"));
+        ui->logDisplay->show();
+    } else {
+        ui->toggleLogButton->setText(tr("Show Log"));
+        ui->logDisplay->hide();
+    }
 
     // handle resize like this for now, we deal with it when we add more docks
     connect(this, &MainWindow::WindowResized, this, [&]() {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -5,7 +5,6 @@
 #include <QKeyEvent>
 #include <QPlainTextEdit>
 #include <QProgressDialog>
-#include <QSplitter>
 #include <QStatusBar>
 
 #include "about_dialog.h"
@@ -924,7 +923,7 @@ void MainWindow::CreateConnects() {
 
 void MainWindow::PrintLog(QString entry, QColor textColor) {
     ui->logDisplay->setTextColor(textColor);
-    ui->logDisplay->append(entry.trimmed());
+    ui->logDisplay->append(entry);
     QScrollBar* sb = ui->logDisplay->verticalScrollBar();
     sb->setValue(sb->maximum());
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -310,9 +310,9 @@ void MainWindow::CreateDockWindows(bool newDock) {
 
     QWidget* dockContents = new QWidget(this);
     QVBoxLayout* dockLayout = new QVBoxLayout(this);
+
     ui->splitter = new QSplitter(Qt::Vertical);
-    ui->logDisplay = new QTextEdit();
-    ui->toggleLogButton = new QPushButton();
+    ui->logDisplay = new QTextEdit(ui->splitter);
 
     if (newDock) {
         m_dock_widget.reset(new QDockWidget(tr("Game List"), this));
@@ -916,14 +916,14 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->toggleLogButton, &QPushButton::clicked, this, [this]() {
-        if (ui->logDisplay->isVisible()) {
-            ui->logDisplay->hide();
-            ui->toggleLogButton->setText(tr("Show Log"));
-            m_gui_settings->SetValue(gui::mw_showLog, false);
-        } else {
+        if (ui->logDisplay->isHidden()) {
             ui->logDisplay->show();
             ui->toggleLogButton->setText(tr("Hide Log"));
             m_gui_settings->SetValue(gui::mw_showLog, true);
+        } else {
+            ui->logDisplay->hide();
+            ui->toggleLogButton->setText(tr("Show Log"));
+            m_gui_settings->SetValue(gui::mw_showLog, false);
         }
     });
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -353,10 +353,19 @@ void MainWindow::CreateDockWindows() {
 
     splitter->addWidget(ui->logDisplay);
     splitter->addWidget(ui->toggleLogButton);
-    ui->toggleLogButton->setText(tr("Hide Log")); // TODO MAKE TOGGLE STATE SAVABLE
 
-    splitter->setSizes({400, 200, 25}); // TODO make savable
-    // TODO show or hide the log this based on toggle state
+    QList<int> sizes = {400, 200, 50};
+    sizes = gui_settings::Var2IntList(m_gui_settings->GetValue(gui::mw_dockWidgetSizes));
+    splitter->setSizes({sizes});
+
+    bool showLog = m_gui_settings->GetValue(gui::mw_showLog).toBool();
+    if (showLog) {
+        ui->toggleLogButton->setText(tr("Hide Log"));
+        ui->logDisplay->show();
+    } else {
+        ui->toggleLogButton->setText(tr("Show Log"));
+        ui->logDisplay->hide();
+    }
 
     dockLayout->addWidget(splitter);
     dockContents->setLayout(dockLayout);
@@ -903,9 +912,11 @@ void MainWindow::CreateConnects() {
         if (ui->logDisplay->isVisible()) {
             ui->logDisplay->hide();
             ui->toggleLogButton->setText(tr("Show Log"));
+            m_gui_settings->SetValue(gui::mw_showLog, false);
         } else {
             ui->logDisplay->show();
             ui->toggleLogButton->setText(tr("Hide Log"));
+            m_gui_settings->SetValue(gui::mw_showLog, true);
         }
     });
 
@@ -1033,6 +1044,18 @@ void MainWindow::ConfigureGuiFromSettings() {
 
 void MainWindow::SaveWindowState() {
     m_gui_settings->SetValue(gui::mw_geometry, saveGeometry(), false);
+
+    int listHeight;
+    if (!m_elf_viewer->isHidden()) {
+        listHeight = m_elf_viewer->height();
+    } else if (!m_game_list_frame->isHidden()) {
+        listHeight = m_game_list_frame->height();
+    } else if (!m_game_grid_frame->isHidden()) {
+        listHeight = m_game_grid_frame->height();
+    }
+
+    QList<int> sizes = {listHeight, ui->logDisplay->height(), ui->toggleLogButton->height()};
+    m_gui_settings->SetValue(gui::mw_dockWidgetSizes, QVariant::fromValue(sizes));
 }
 
 void MainWindow::BootGame() {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -68,6 +68,7 @@ private:
     void LoadGameLists();
     void onGameClosed();
     void RunGame();
+    void PrintLog(QString entry, QColor textColor);
 
 #ifdef ENABLE_UPDATER
     void CheckUpdateMain(bool checkSave);

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -64,7 +64,7 @@ private:
     void CreateActions();
     void toggleFullscreen();
     void CreateRecentGameActions();
-    void CreateDockWindows();
+    void CreateDockWindows(bool newDock);
     void LoadGameLists();
     void onGameClosed();
     void RunGame();

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -11,9 +11,9 @@
 
 class Ui_MainWindow {
 public:
-    QTextEdit* logDisplay;
-    QPushButton* toggleLogButton;
+    QPushButton* toggleLogButton = new QPushButton();
     QSplitter* splitter;
+    QTextEdit* logDisplay;
 
     QAction* bootGameAct;
     QAction* addElfFolderAct;

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -10,6 +10,9 @@
 
 class Ui_MainWindow {
 public:
+    QTextEdit* logDisplay = new QTextEdit();
+    QPushButton* toggleLogButton = new QPushButton();
+
     QAction* bootGameAct;
     QAction* addElfFolderAct;
     QAction* shadFolderAct;
@@ -71,9 +74,6 @@ public:
     QMenu* menuThemes;
     QMenu* menuHelp;
     QToolBar* toolBar;
-
-    QTextEdit* logDisplay;
-    QPushButton* toggleLogButton;
 
     void setupUi(QMainWindow* MainWindow) {
         if (MainWindow->objectName().isEmpty())
@@ -359,9 +359,6 @@ public:
         versionComboBox->setObjectName("versionComboBox");
         versionComboBox->setMinimumWidth(100);
         versionManagerButton = new QPushButton(centralWidget);
-
-        logDisplay = new QTextEdit();
-        toggleLogButton = new QPushButton();
 
         retranslateUi(MainWindow);
 

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -5,13 +5,15 @@
 
 #include <QMenuBar>
 #include <QPushButton>
+#include <QSplitter>
 #include <QTextEdit>
 #include <QToolBar>
 
 class Ui_MainWindow {
 public:
-    QTextEdit* logDisplay = new QTextEdit();
-    QPushButton* toggleLogButton = new QPushButton();
+    QTextEdit* logDisplay;
+    QPushButton* toggleLogButton;
+    QSplitter* splitter;
 
     QAction* bootGameAct;
     QAction* addElfFolderAct;

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -11,15 +11,14 @@
 
 class Ui_MainWindow {
 public:
-    QPushButton* toggleLogButton = new QPushButton();
     QSplitter* splitter;
     QTextEdit* logDisplay;
-
     QAction* bootGameAct;
     QAction* addElfFolderAct;
     QAction* shadFolderAct;
     QAction* exitAct;
     QAction* showGameListAct;
+    QAction* showLogAct;
     QAction* refreshGameListAct;
     QAction* setIconSizeTinyAct;
     QAction* setIconSizeSmallAct;
@@ -110,6 +109,9 @@ public:
         showGameListAct = new QAction(MainWindow);
         showGameListAct->setObjectName("showGameListAct");
         showGameListAct->setCheckable(true);
+        showLogAct = new QAction(MainWindow);
+        showLogAct->setObjectName("showLogAct");
+        showLogAct->setCheckable(true);
         refreshGameListAct = new QAction(MainWindow);
         refreshGameListAct->setObjectName("refreshGameListAct");
         refreshGameListAct->setIcon(QIcon(":images/refreshlist_icon.png"));
@@ -323,6 +325,7 @@ public:
         menuFile->addSeparator();
         menuFile->addAction(exitAct);
         menuView->addAction(showGameListAct);
+        menuView->addAction(showLogAct);
         menuView->addSeparator();
         menuView->addAction(refreshGameListAct);
         menuView->addAction(menuGame_List_Mode->menuAction());
@@ -395,6 +398,7 @@ public:
 #endif // QT_CONFIG(statustip)
         showGameListAct->setText(
             QCoreApplication::translate("MainWindow", "Show Game List", nullptr));
+        showLogAct->setText(QCoreApplication::translate("MainWindow", "Show Game Log", nullptr));
         refreshGameListAct->setText(
             QCoreApplication::translate("MainWindow", "Game List Refresh", nullptr));
         setIconSizeTinyAct->setText(QCoreApplication::translate("MainWindow", "Tiny", nullptr));

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -5,6 +5,7 @@
 
 #include <QMenuBar>
 #include <QPushButton>
+#include <QTextEdit>
 #include <QToolBar>
 
 class Ui_MainWindow {
@@ -70,6 +71,9 @@ public:
     QMenu* menuThemes;
     QMenu* menuHelp;
     QToolBar* toolBar;
+
+    QTextEdit* logDisplay;
+    QPushButton* toggleLogButton;
 
     void setupUi(QMainWindow* MainWindow) {
         if (MainWindow->objectName().isEmpty())
@@ -355,6 +359,9 @@ public:
         versionComboBox->setObjectName("versionComboBox");
         versionComboBox->setMinimumWidth(100);
         versionManagerButton = new QPushButton(centralWidget);
+
+        logDisplay = new QTextEdit();
+        toggleLogButton = new QPushButton();
 
         retranslateUi(MainWindow);
 

--- a/src/qt_gui/settings.cpp
+++ b/src/qt_gui/settings.cpp
@@ -89,3 +89,15 @@ QList<QString> settings::Var2List(const QVariant& var) {
     stream >> list;
     return list;
 }
+
+QList<int> settings::Var2IntList(const QVariant& var) {
+    QList<int> intList;
+    QList<QVariant> qVariantList = var.toList();
+    for (const QVariant& item : qVariantList) {
+        if (item.canConvert<int>()) {
+            intList.append(item.toInt());
+        }
+    }
+
+    return intList;
+}

--- a/src/qt_gui/settings.h
+++ b/src/qt_gui/settings.h
@@ -37,6 +37,7 @@ public:
     QVariant GetValue(const gui_value& entry) const;
     static QVariant List2Var(const QList<QString>& list);
     static QList<QString> Var2List(const QVariant& var);
+    static QList<int> Var2IntList(const QVariant& var);
 
 public Q_SLOTS:
     /** Remove entry */


### PR DESCRIPTION
Had a holiday this weekend, so was able to find time for this thing I've wanted to do for awhile

One annoying thing about using the Qt Gui on Windows is that it forces 3 windows to be open for shadPS4. This takes the terminal window and puts in into the main window instead. The log widget can be resized or hidden, and the corresponding settings are saved. This also allows Linux/Mac users to easily see the log when launching from the GUI.

Colored logs can be implemented here as well, so this can close https://github.com/shadps4-emu/shadps4-qtlauncher/issues/158. I don't know of a way to have Windows terminals output its ANSI formatting from ReadAllStandardOutput(), so this is just done by checking if a string has Warning, Error, or Critical.

<img width="1482" height="864" alt="image" src="https://github.com/user-attachments/assets/6d369913-92c4-4ba1-b38a-44eb41817d27" />
 