### PR TITLE
Version Manager fixes

### DIFF
--- a/src/common/versions.cpp
+++ b/src/common/versions.cpp
@@ -100,6 +100,11 @@ void SaveVersionList(std::vector<Version> const& versions, std::filesystem::path
 
 void AddNewVersion(Version const& v, std::filesystem::path const& path) {
     auto versions = GetVersionList(path);
+    auto it = std::remove_if(versions.begin(), versions.end(),
+                             [&](const Version& existing) { return existing.name == v.name; });
+    if (it != versions.end())
+        versions.erase(it, versions.end());
+
     versions.push_back(v);
     SaveVersionList(versions, path);
 }

--- a/src/qt_gui/infinity_dialog.cpp
+++ b/src/qt_gui/infinity_dialog.cpp
@@ -413,9 +413,9 @@ figure_creator_dialog::figure_creator_dialog(QWidget* parent, u8 slot) : QDialog
     QHBoxLayout* hbox_filters = new QHBoxLayout();
     QLabel* filter_label = new QLabel(tr("Filter by Series:"));
     QPushButton* btn_all = new QPushButton(tr("All"));
-    QPushButton* btn_series1 = new QPushButton(tr("1.0"));
-    QPushButton* btn_series2 = new QPushButton(tr("2.0"));
-    QPushButton* btn_series3 = new QPushButton(tr("3.0"));
+    QPushButton* btn_series1 = new QPushButton("1.0");
+    QPushButton* btn_series2 = new QPushButton("2.0");
+    QPushButton* btn_series3 = new QPushButton("3.0");
 
     // Style the active filter button
     btn_all->setCheckable(true);

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -831,29 +831,19 @@ void VersionDialog::checkUpdatePre(const bool showMessage) {
                 }
 
                 if (localHash.isEmpty()) {
-                    QMessageBox::StandardButton reply =
-                        QMessageBox::question(this, tr("No pre-release found"),
-                                              // clang-format off
-            tr("You don't have any pre-release installed yet.\nWould you like to download it now?"),
-                                              // clang-format on
-                                              QMessageBox::Yes | QMessageBox::No);
-                    if (reply == QMessageBox::Yes) {
-                        auto* tree = ui->downloadTreeWidget;
-                        int topCount = tree->topLevelItemCount();
+                    auto* tree = ui->downloadTreeWidget;
+                    int topCount = tree->topLevelItemCount();
 
-                        for (int i = 0; i < topCount; ++i) {
-                            QTreeWidgetItem* item = tree->topLevelItem(i);
-                            if (item &&
-                                item->text(0).contains("Pre-release", Qt::CaseInsensitive)) {
-                                tree->setCurrentItem(item);
-                                tree->scrollToItem(item);
-                                tree->setFocus();
-                                emit tree->itemClicked(item, 0);
-                                break;
-                            }
+                    for (int i = 0; i < topCount; ++i) {
+                        QTreeWidgetItem* item = tree->topLevelItem(i);
+                        if (item && item->text(0).contains("Pre-release", Qt::CaseInsensitive)) {
+                            tree->setCurrentItem(item);
+                            tree->scrollToItem(item);
+                            tree->setFocus();
+                            emit tree->itemClicked(item, 0);
+                            break;
                         }
                     }
-                    return;
                 }
 
                 if (latestHash == localHash) {
@@ -871,6 +861,9 @@ void VersionDialog::checkUpdatePre(const bool showMessage) {
 
 void VersionDialog::showPreReleaseUpdateDialog(const QString& localHash, const QString& latestHash,
                                                const QString& latestTag) {
+    if (localHash == "") {
+        return;
+    }
     QDialog dialog(this);
     dialog.setWindowTitle(tr("Auto Updater - Emulator"));
 

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -114,11 +114,11 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
 
         version_name = version_name.trimmed();
 
-        if (version_name.compare("Pre-release", Qt::CaseInsensitive) == 0 ||
-            version_name.compare("Pre-release-shadPS4", Qt::CaseInsensitive) == 0) {
+        if (version_name.startsWith("Pre-release", Qt::CaseInsensitive) ||
+            version_name.startsWith("Pre-release-shadPS4", Qt::CaseInsensitive)) {
             QMessageBox::warning(this, tr("Error"),
                                  // clang-format off
-tr("It is not possible to create a version with the name:\n'Pre-release' or 'Pre-release-shadPS4'."));
+tr("It is not possible to create a version with a name that starts with:\n'Pre-release' or 'Pre-release-shadPS4'."));
             // clang-format on
             return;
         }

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -178,10 +178,6 @@ tr("It is not possible to create a version with the name:\n'Pre-release' or 'Pre
         }
 
         if (versionType == 2) {
-            QMessageBox::information(this, tr("Local version"),
-                                     // clang-format off
-tr("Local versions cannot be deleted from disk.\nIt will only be removed from the list."));
-            // clang-format on
             VersionManager::RemoveVersion(versionName.toStdString());
             LoadInstalledList();
             return;
@@ -842,7 +838,20 @@ void VersionDialog::checkUpdatePre(const bool showMessage) {
                                               // clang-format on
                                               QMessageBox::Yes | QMessageBox::No);
                     if (reply == QMessageBox::Yes) {
-                        installPreReleaseByTag(latestTag);
+                        auto* tree = ui->downloadTreeWidget;
+                        int topCount = tree->topLevelItemCount();
+
+                        for (int i = 0; i < topCount; ++i) {
+                            QTreeWidgetItem* item = tree->topLevelItem(i);
+                            if (item &&
+                                item->text(0).contains("Pre-release", Qt::CaseInsensitive)) {
+                                tree->setCurrentItem(item);
+                                tree->scrollToItem(item);
+                                tree->setFocus();
+                                emit tree->itemClicked(item, 0);
+                                break;
+                            }
+                        }
                     }
                     return;
                 }


### PR DESCRIPTION
When downloading a version, the system now checks if a version with the same name already exists and deletes the old one to avoid duplicate entries.

Prevented the creation of local folders named "Pre-release" or "Pre-release-shadPS4".

**Code Name**
- Pre-release versions now receive the first 7 characters of the hash as their code name.
- Local versions now always receive the code name "Local".

**Date Format**
- Standardized all displayed dates to the format yyyy-MM-dd (e.g. 2025-10-31).

**Deletion Logic**
- Reintroduced folder deletion functionality, except for local builds.

**Ordering**
- The list of installed versions is now correctly ordered as follows: Pre-release, release, custom.
- If there are any items in the list, 'None' will not appear; it only appears if the list is empty.

**Bug Fixes**
- Fixed an issue where downloading a version would start twice after refreshing the download list.

**Issue 172**
- It also corrects [Issue 172](https://github.com/shadps4-emu/shadps4-qtlauncher/issues/172), where clicking on 'Check for Pre-release Updates' and the user did not have a pre-release downloaded, it was not indexed correctly.

**Extra**
- Removed unnecessary translations for 1.0,  2.0,  3.0

<img width="802" height="532" alt="image" src="https://github.com/user-attachments/assets/d6ddd326-0663-4cd2-a6aa-69f73c76ba4e" />
<img width="112" height="205" alt="image" src="https://github.com/user-attachments/assets/c4a6ed3b-8826-451b-837e-5f97e3ee103f" />

