### PR TITLE
Use Write mode instead of ReadWrite for creating figures

### DIFF
--- a/src/qt_gui/dimensions_dialog.cpp
+++ b/src/qt_gui/dimensions_dialog.cpp
@@ -465,8 +465,7 @@ minifig_creator_dialog::minifig_creator_dialog(QWidget* parent) : QDialog(parent
             return;
         }
 
-        Common::FS::IOFile dim_file(m_file_path.toStdString(),
-                                    Common::FS::FileAccessMode::ReadWrite);
+        Common::FS::IOFile dim_file(m_file_path.toStdString(), Common::FS::FileAccessMode::Write);
         if (!dim_file.IsOpen()) {
             QMessageBox::warning(this, tr("Failed to create minifig file!"),
                                  tr("Failed to create minifig file:\n%1").arg(m_file_path),

--- a/src/qt_gui/infinity_dialog.cpp
+++ b/src/qt_gui/infinity_dialog.cpp
@@ -585,7 +585,7 @@ figure_creator_dialog::figure_creator_dialog(QWidget* parent, u8 slot) : QDialog
 }
 
 bool figure_creator_dialog::create_blank_figure(u32 character, u8 series) {
-    Common::FS::IOFile inf_file(m_file_path.toStdString(), Common::FS::FileAccessMode::ReadWrite);
+    Common::FS::IOFile inf_file(m_file_path.toStdString(), Common::FS::FileAccessMode::Write);
     if (!inf_file.IsOpen()) {
         return false;
     }

--- a/src/qt_gui/skylander_dialog.cpp
+++ b/src/qt_gui/skylander_dialog.cpp
@@ -639,7 +639,7 @@ skylander_creator_dialog::skylander_creator_dialog(QWidget* parent) : QDialog(pa
             return;
         }
 
-        Common::FS::IOFile sky_file(file_path.toStdString(), Common::FS::FileAccessMode::ReadWrite);
+        Common::FS::IOFile sky_file(file_path.toStdString(), Common::FS::FileAccessMode::Write);
         if (!sky_file.IsOpen()) {
             QMessageBox::warning(this, tr("Failed to create skylander file!"),
                                  tr("Failed to create skylander file:\n%1").arg(file_path),


### PR DESCRIPTION
ReadWrite mode caused the creation of files to fail when creating new figures for the emulated devices, change to Write mode to ensure files are created