### PR TITLE
MacOS: Universal Binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,6 @@ jobs:
   macos-qt:
     runs-on: macos-latest
     needs: get-info
-    strategy:
-      matrix:
-        arch: [ "arm64", "x86_64" ]
     steps:
     - uses: actions/checkout@v5
       with:
@@ -151,7 +148,7 @@ jobs:
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 
-          cache-name: ${{ runner.os }}-${{ matrix.arch }}-qt-cache-cmake-configuration
+          cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
       with: 
           path: |  
             ${{github.workspace}}/build 
@@ -162,7 +159,7 @@ jobs:
     - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.19
       env:
-          cache-name: ${{ runner.os }}-${{ matrix.arch }}-qt-cache-cmake-build
+          cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
         append-timestamp: false
         create-symlink: true
@@ -170,7 +167,7 @@ jobs:
         variant: sccache
 
     - name: Configure CMake
-      run: cmake --fresh -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DENABLE_UPDATER=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+      run: cmake --fresh -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DENABLE_UPDATER=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --parallel $(sysctl -n hw.ncpu)
@@ -181,11 +178,11 @@ jobs:
         mv ${{ github.workspace }}/build/shadPS4QtLauncher.app upload
         macdeployqt upload/shadPS4QtLauncher.app
         codesign --deep -fs - upload/shadPS4QtLauncher.app
-        tar cf shadPS4QtLauncher-macos-${{ matrix.arch }}-qt.tar.gz -C upload .
+        tar cf shadPS4QtLauncher-macos-qt.tar.gz -C upload .
     - uses: actions/upload-artifact@v4
       with:
-        name: shadPS4QtLauncher-macos-${{ matrix.arch }}-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
-        path: shadPS4QtLauncher-macos-${{ matrix.arch }}-qt.tar.gz
+        name: shadPS4QtLauncher-macos-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
+        path: shadPS4QtLauncher-macos-qt.tar.gz
 
   linux-qt:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Noticed when using the Qt Launcher that the check for updates action was broken on MacOS, because the files are named 
shadPS4QtLauncher-macos-{arch}-qt rather than just macos-qt. Slightly changed the pipeline to use the builtin CMAKE_OSX_ARCHITECTURES as both x86_64 and arm64 at the same time (which works using the qt action on the pipeline, but not locally with a brew install of qt). Other option would be to change [this line](https://github.com/shadps4-emu/shadps4-qtlauncher/blob/d0c3bd6491f07d11b5b6a334ed540b57d767d1c2/src/qt_gui/check_update.cpp#L97) to do an #if defined(__x86_64__) || defined(_M_X64) #elif defined(__aarch64__) || defined(_M_ARM64) but figured this was the simpler solution