### PR TITLE
Make FSR off by default

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -177,7 +177,7 @@ static ConfigEntry<bool> isFullscreen(false);
 static ConfigEntry<string> fullscreenMode("Windowed");
 static ConfigEntry<string> presentMode("Mailbox");
 static ConfigEntry<bool> isHDRAllowed(false);
-static ConfigEntry<bool> fsrEnabled(true);
+static ConfigEntry<bool> fsrEnabled(false);
 static ConfigEntry<bool> rcasEnabled(true);
 static ConfigEntry<int> rcasAttenuation(250);
 


### PR DESCRIPTION
Same thing as https://github.com/shadps4-emu/shadPS4/pull/3801

Not sure why the code is duplicated between the launcher and the emulator, but I mistakenly opened the PR in the emulator repo, that doesn't do anything since the launcher still has the setting turned on.