### PR TITLE
Pre-release Folder Persistence

### DIFF
--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -114,13 +114,6 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
 
         version_name = version_name.trimmed();
 
-        if (version_name.compare("Pre-release", Qt::CaseInsensitive) == 0) {
-            QMessageBox::warning(
-                this, tr("Error"),
-                tr("It is not possible to create a version named exactly 'Pre-release'."));
-            return;
-        }
-
         if (std::find_if(version_list.cbegin(), version_list.cend(), [version_name](auto i) {
                 return i.name == version_name.toStdString();
             }) != version_list.cend()) {


### PR DESCRIPTION
Resolves https://github.com/shadps4-emu/shadps4-qtlauncher/issues/198

Pre-release versions now install to a single 'Pre-release' folder without deleting existing files, ensuring persistent updates.

<img width="453" height="160" alt="image" src="https://github.com/user-attachments/assets/15b301e2-8dbd-4c84-be56-eb9607951c4d" />


Previously, Pre-release versions were saved in folders with long names that included the commit hash. On each update, the entire folder was deleted, including any files inside it (such as settings, screenshots, mods, or anything else), causing loss of user data.

Now, all Pre-release versions are installed in the fixed Pre-release folder. When updating, only the shadPS4.exe executable is replaced, preserving all other files.

