### PR TITLE
Remapping gui improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/version_dialog.ui
            src/qt_gui/create_shortcut.cpp
            src/qt_gui/create_shortcut.h
+           src/qt_gui/right_click_button.cpp
+           src/qt_gui/right_click_button.h
            ${RESOURCE_FILES}
            ${TRANSLATIONS}
            ${UPDATER}

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -4,8 +4,10 @@
 #include <QDialog>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gamepad.h>
+
 #include "game_info.h"
 #include "ipc/ipc_client.h"
+#include "right_click_button.h"
 #include "sdl_event_wrapper.h"
 
 namespace Ui {
@@ -28,9 +30,9 @@ private Q_SLOTS:
     void SaveControllerConfig(bool CloseOnSave);
     void SetDefault();
     void UpdateLightbarColor();
-    void CheckMapping(QPushButton*& button);
-    void StartTimer(QPushButton*& button, bool isButton);
-    void ConnectAxisInputs(QPushButton*& button);
+    void CheckMapping(QRightClickButton*& button);
+    void StartTimer(QRightClickButton*& button, bool isButton);
+    void ConnectAxisInputs(QRightClickButton*& button);
     void ActiveControllerChanged(int value);
 
 private:
@@ -52,8 +54,8 @@ private:
 
     // use QMap instead of QSet to maintain order of inserted strings
     QMap<int, QString> pressedButtons;
-    QList<QPushButton*> ButtonsList;
-    QList<QPushButton*> AxisList;
+    QList<QRightClickButton*> ButtonsList;
+    QList<QRightClickButton*> AxisList;
 
     std::string RunningGameSerial;
     bool GameRunning;
@@ -66,7 +68,7 @@ private:
     int MappingTimer;
     int gamepad_count;
     QTimer* timer;
-    QPushButton* MappingButton;
+    QRightClickButton* MappingButton;
     SDL_Gamepad* gamepad = nullptr;
     SDL_JoystickID* gamepads;
     SdlEventWrapper::Wrapper* RemapWrapper;

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>1124</width>
-    <height>857</height>
+    <height>904</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,7 +46,7 @@
         <x>0</x>
         <y>0</y>
         <width>1110</width>
-        <height>819</height>
+        <height>862</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -145,7 +145,7 @@
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_4">
                     <item>
-                     <widget class="QPushButton" name="DpadUpButton">
+                     <widget class="QRightClickButton" name="DpadUpButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -181,7 +181,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="DpadLeftButton">
+                    <widget class="QRightClickButton" name="DpadLeftButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -212,7 +212,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="DpadRightButton">
+                    <widget class="QRightClickButton" name="DpadRightButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -260,7 +260,7 @@
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_3">
                     <item>
-                     <widget class="QPushButton" name="DpadDownButton">
+                     <widget class="QRightClickButton" name="DpadDownButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -309,7 +309,7 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QPushButton" name="L1Button">
+                  <widget class="QRightClickButton" name="L1Button">
                    <property name="text">
                     <string>unmapped</string>
                    </property>
@@ -340,7 +340,7 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QPushButton" name="L2Button">
+                  <widget class="QRightClickButton" name="L2Button">
                    <property name="text">
                     <string>unmapped</string>
                    </property>
@@ -549,7 +549,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_10">
                     <item>
-                     <widget class="QPushButton" name="LStickUpButton">
+                     <widget class="QRightClickButton" name="LStickUpButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -585,7 +585,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="LStickLeftButton">
+                    <widget class="QRightClickButton" name="LStickLeftButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -598,7 +598,7 @@
                  <widget class="QGroupBox" name="gb_left_stick_right">
                   <property name="maximumSize">
                    <size>
-                    <width>179</width>
+                    <width>16777215</width>
                     <height>16777215</height>
                    </size>
                   </property>
@@ -622,7 +622,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="LStickRightButton">
+                    <widget class="QRightClickButton" name="LStickRightButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -670,7 +670,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_8">
                     <item>
-                     <widget class="QPushButton" name="LStickDownButton">
+                     <widget class="QRightClickButton" name="LStickDownButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -967,7 +967,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="L3Button">
+                   <widget class="QRightClickButton" name="L3Button">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -998,7 +998,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="OptionsButton">
+                   <widget class="QRightClickButton" name="OptionsButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1035,7 +1035,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="R3Button">
+                   <widget class="QRightClickButton" name="R3Button">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1058,7 +1058,7 @@
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout_5">
                   <item>
-                   <widget class="QPushButton" name="TouchpadLeftButton">
+                   <widget class="QRightClickButton" name="TouchpadLeftButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1077,7 +1077,7 @@
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_11">
                   <item>
-                   <widget class="QPushButton" name="TouchpadCenterButton">
+                   <widget class="QRightClickButton" name="TouchpadCenterButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1096,7 +1096,7 @@
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_12">
                   <item>
-                   <widget class="QPushButton" name="TouchpadRightButton">
+                   <widget class="QRightClickButton" name="TouchpadRightButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1167,7 +1167,7 @@
                      <widget class="QLabel" name="RLabel">
                       <property name="maximumSize">
                        <size>
-                        <width>20</width>
+                        <width>25</width>
                         <height>16777215</height>
                        </size>
                       </property>
@@ -1212,7 +1212,7 @@
                      <widget class="QLabel" name="GLabel">
                       <property name="maximumSize">
                        <size>
-                        <width>20</width>
+                        <width>25</width>
                         <height>16777215</height>
                        </size>
                       </property>
@@ -1260,7 +1260,7 @@
                      <widget class="QLabel" name="BLabel">
                       <property name="maximumSize">
                        <size>
-                        <width>20</width>
+                        <width>25</width>
                         <height>16777215</height>
                        </size>
                       </property>
@@ -1392,7 +1392,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_3">
                     <item>
-                     <widget class="QPushButton" name="TriangleButton">
+                     <widget class="QRightClickButton" name="TriangleButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -1428,7 +1428,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="SquareButton">
+                    <widget class="QRightClickButton" name="SquareButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -1459,7 +1459,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="CircleButton">
+                    <widget class="QRightClickButton" name="CircleButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -1507,7 +1507,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_5">
                     <item>
-                     <widget class="QPushButton" name="CrossButton">
+                     <widget class="QRightClickButton" name="CrossButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -1556,7 +1556,7 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QPushButton" name="R1Button">
+                  <widget class="QRightClickButton" name="R1Button">
                    <property name="text">
                     <string>unmapped</string>
                    </property>
@@ -1587,7 +1587,7 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QPushButton" name="R2Button">
+                  <widget class="QRightClickButton" name="R2Button">
                    <property name="text">
                     <string>unmapped</string>
                    </property>
@@ -1799,7 +1799,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_7">
                     <item>
-                     <widget class="QPushButton" name="RStickUpButton">
+                     <widget class="QRightClickButton" name="RStickUpButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -1835,7 +1835,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="RStickLeftButton">
+                    <widget class="QRightClickButton" name="RStickLeftButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -1866,7 +1866,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="RStickRightButton">
+                    <widget class="QRightClickButton" name="RStickRightButton">
                      <property name="text">
                       <string>unmapped</string>
                      </property>
@@ -1914,7 +1914,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_6">
                     <item>
-                     <widget class="QPushButton" name="RStickDownButton">
+                     <widget class="QRightClickButton" name="RStickDownButton">
                       <property name="text">
                        <string>unmapped</string>
                       </property>
@@ -1938,17 +1938,52 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_23">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Tip: Unmap inputs with right-click</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LayoutDirection::LeftToRight</enum>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+       </property>
+       <property name="centerButtons">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QRightClickButton</class>
+   <extends>QPushButton</extends>
+   <header>src/qt_gui/right_click_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../shadps4.qrc"/>
  </resources>

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -422,361 +422,361 @@ bool Hotkeys::eventFilter(QObject* obj, QEvent* event) {
                 break;
             case Qt::Key_Meta:
 #ifdef _WIN32
-                    pressedButtons.insert(7, "lwin");
+                pressedButtons.insert(7, "lwin");
 #else
-                    pressedButtons.insert(7, "lmeta");
+                pressedButtons.insert(7, "lmeta");
 #endif
-                    break;
+                break;
 
-                    // f keys
+                // f keys
 
-                case Qt::Key_F1:
-                    pressedButtons.insert(8, "f1");
-                    break;
-                case Qt::Key_F2:
-                    pressedButtons.insert(9, "f2");
-                    break;
-                case Qt::Key_F3:
-                    pressedButtons.insert(10, "f3");
-                    break;
-                case Qt::Key_F4:
-                    pressedButtons.insert(11, "f4");
-                    break;
-                case Qt::Key_F5:
-                    pressedButtons.insert(12, "f5");
-                    break;
-                case Qt::Key_F6:
-                    pressedButtons.insert(13, "f6");
-                    break;
-                case Qt::Key_F7:
-                    pressedButtons.insert(14, "f7");
-                    break;
-                case Qt::Key_F8:
-                    pressedButtons.insert(15, "f8");
-                    break;
-                case Qt::Key_F9:
-                    pressedButtons.insert(16, "f9");
-                    break;
-                case Qt::Key_F10:
-                    pressedButtons.insert(17, "f10");
-                    break;
-                case Qt::Key_F11:
-                    pressedButtons.insert(18, "f11");
-                    break;
-                case Qt::Key_F12:
-                    pressedButtons.insert(19, "f12");
-                    break;
+            case Qt::Key_F1:
+                pressedButtons.insert(8, "f1");
+                break;
+            case Qt::Key_F2:
+                pressedButtons.insert(9, "f2");
+                break;
+            case Qt::Key_F3:
+                pressedButtons.insert(10, "f3");
+                break;
+            case Qt::Key_F4:
+                pressedButtons.insert(11, "f4");
+                break;
+            case Qt::Key_F5:
+                pressedButtons.insert(12, "f5");
+                break;
+            case Qt::Key_F6:
+                pressedButtons.insert(13, "f6");
+                break;
+            case Qt::Key_F7:
+                pressedButtons.insert(14, "f7");
+                break;
+            case Qt::Key_F8:
+                pressedButtons.insert(15, "f8");
+                break;
+            case Qt::Key_F9:
+                pressedButtons.insert(16, "f9");
+                break;
+            case Qt::Key_F10:
+                pressedButtons.insert(17, "f10");
+                break;
+            case Qt::Key_F11:
+                pressedButtons.insert(18, "f11");
+                break;
+            case Qt::Key_F12:
+                pressedButtons.insert(19, "f12");
+                break;
 
-                // alphanumeric
-                case Qt::Key_A:
-                    pressedButtons.insert(20, "a");
-                    break;
-                case Qt::Key_B:
-                    pressedButtons.insert(21, "b");
-                    break;
-                case Qt::Key_C:
-                    pressedButtons.insert(22, "c");
-                    break;
-                case Qt::Key_D:
-                    pressedButtons.insert(23, "d");
-                    break;
-                case Qt::Key_E:
-                    pressedButtons.insert(24, "e");
-                    break;
-                case Qt::Key_F:
-                    pressedButtons.insert(25, "f");
-                    break;
-                case Qt::Key_G:
-                    pressedButtons.insert(26, "g");
-                    break;
-                case Qt::Key_H:
-                    pressedButtons.insert(27, "h");
-                    break;
-                case Qt::Key_I:
-                    pressedButtons.insert(28, "i");
-                    break;
-                case Qt::Key_J:
-                    pressedButtons.insert(29, "j");
-                    break;
-                case Qt::Key_K:
-                    pressedButtons.insert(30, "k");
-                    break;
-                case Qt::Key_L:
-                    pressedButtons.insert(31, "l");
-                    break;
-                case Qt::Key_M:
-                    pressedButtons.insert(32, "m");
-                    break;
-                case Qt::Key_N:
-                    pressedButtons.insert(33, "n");
-                    break;
-                case Qt::Key_O:
-                    pressedButtons.insert(34, "o");
-                    break;
-                case Qt::Key_P:
-                    pressedButtons.insert(35, "p");
-                    break;
-                case Qt::Key_Q:
-                    pressedButtons.insert(36, "q");
-                    break;
-                case Qt::Key_R:
-                    pressedButtons.insert(37, "r");
-                    break;
-                case Qt::Key_S:
-                    pressedButtons.insert(38, "s");
-                    break;
-                case Qt::Key_T:
-                    pressedButtons.insert(39, "t");
-                    break;
-                case Qt::Key_U:
-                    pressedButtons.insert(40, "u");
-                    break;
-                case Qt::Key_V:
-                    pressedButtons.insert(41, "v");
-                    break;
-                case Qt::Key_W:
-                    pressedButtons.insert(42, "w");
-                    break;
-                case Qt::Key_X:
-                    pressedButtons.insert(43, "x");
-                    break;
-                case Qt::Key_Y:
-                    pressedButtons.insert(44, "y");
-                    break;
-                case Qt::Key_Z:
-                    pressedButtons.insert(45, "z");
-                    break;
-                case Qt::Key_0:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(46, "kp0")
-                        : pressedButtons.insert(56, "0");
-                    break;
-                case Qt::Key_1:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(47, "kp1")
-                        : pressedButtons.insert(57, "1");
-                    break;
-                case Qt::Key_2:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(48, "kp2")
-                        : pressedButtons.insert(58, "2");
-                    break;
-                case Qt::Key_3:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(49, "kp3")
-                        : pressedButtons.insert(59, "3");
-                    break;
-                case Qt::Key_4:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(50, "kp4")
-                        : pressedButtons.insert(60, "4");
-                    break;
-                case Qt::Key_5:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(51, "kp5")
-                        : pressedButtons.insert(61, "5");
-                    break;
-                case Qt::Key_6:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(52, "kp6")
-                        : pressedButtons.insert(62, "6");
-                    break;
-                case Qt::Key_7:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(53, "kp7")
-                        : pressedButtons.insert(63, "7");
-                    break;
-                case Qt::Key_8:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(54, "kp8")
-                        : pressedButtons.insert(64, "8");
-                    break;
-                case Qt::Key_9:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(55, "kp9")
-                        : pressedButtons.insert(65, "9");
-                    break;
+            // alphanumeric
+            case Qt::Key_A:
+                pressedButtons.insert(20, "a");
+                break;
+            case Qt::Key_B:
+                pressedButtons.insert(21, "b");
+                break;
+            case Qt::Key_C:
+                pressedButtons.insert(22, "c");
+                break;
+            case Qt::Key_D:
+                pressedButtons.insert(23, "d");
+                break;
+            case Qt::Key_E:
+                pressedButtons.insert(24, "e");
+                break;
+            case Qt::Key_F:
+                pressedButtons.insert(25, "f");
+                break;
+            case Qt::Key_G:
+                pressedButtons.insert(26, "g");
+                break;
+            case Qt::Key_H:
+                pressedButtons.insert(27, "h");
+                break;
+            case Qt::Key_I:
+                pressedButtons.insert(28, "i");
+                break;
+            case Qt::Key_J:
+                pressedButtons.insert(29, "j");
+                break;
+            case Qt::Key_K:
+                pressedButtons.insert(30, "k");
+                break;
+            case Qt::Key_L:
+                pressedButtons.insert(31, "l");
+                break;
+            case Qt::Key_M:
+                pressedButtons.insert(32, "m");
+                break;
+            case Qt::Key_N:
+                pressedButtons.insert(33, "n");
+                break;
+            case Qt::Key_O:
+                pressedButtons.insert(34, "o");
+                break;
+            case Qt::Key_P:
+                pressedButtons.insert(35, "p");
+                break;
+            case Qt::Key_Q:
+                pressedButtons.insert(36, "q");
+                break;
+            case Qt::Key_R:
+                pressedButtons.insert(37, "r");
+                break;
+            case Qt::Key_S:
+                pressedButtons.insert(38, "s");
+                break;
+            case Qt::Key_T:
+                pressedButtons.insert(39, "t");
+                break;
+            case Qt::Key_U:
+                pressedButtons.insert(40, "u");
+                break;
+            case Qt::Key_V:
+                pressedButtons.insert(41, "v");
+                break;
+            case Qt::Key_W:
+                pressedButtons.insert(42, "w");
+                break;
+            case Qt::Key_X:
+                pressedButtons.insert(43, "x");
+                break;
+            case Qt::Key_Y:
+                pressedButtons.insert(44, "y");
+                break;
+            case Qt::Key_Z:
+                pressedButtons.insert(45, "z");
+                break;
+            case Qt::Key_0:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(46, "kp0")
+                    : pressedButtons.insert(56, "0");
+                break;
+            case Qt::Key_1:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(47, "kp1")
+                    : pressedButtons.insert(57, "1");
+                break;
+            case Qt::Key_2:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(48, "kp2")
+                    : pressedButtons.insert(58, "2");
+                break;
+            case Qt::Key_3:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(49, "kp3")
+                    : pressedButtons.insert(59, "3");
+                break;
+            case Qt::Key_4:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(50, "kp4")
+                    : pressedButtons.insert(60, "4");
+                break;
+            case Qt::Key_5:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(51, "kp5")
+                    : pressedButtons.insert(61, "5");
+                break;
+            case Qt::Key_6:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(52, "kp6")
+                    : pressedButtons.insert(62, "6");
+                break;
+            case Qt::Key_7:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(53, "kp7")
+                    : pressedButtons.insert(63, "7");
+                break;
+            case Qt::Key_8:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(54, "kp8")
+                    : pressedButtons.insert(64, "8");
+                break;
+            case Qt::Key_9:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(55, "kp9")
+                    : pressedButtons.insert(65, "9");
+                break;
 
-                    // symbols
-                case Qt::Key_Asterisk:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(66, "kpasterisk")
-                        : pressedButtons.insert(74, "asterisk");
-                    break;
-                case Qt::Key_Minus:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(67, "kpminus")
-                        : pressedButtons.insert(75, "minus");
-                    break;
-                case Qt::Key_Equal:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(68, "kpequals")
-                        : pressedButtons.insert(76, "equals");
-                    break;
-                case Qt::Key_Plus:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(69, "kpplus")
-                        : pressedButtons.insert(77, "plus");
-                    break;
-                case Qt::Key_Slash:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(70, "kpslash")
-                        : pressedButtons.insert(78, "slash");
-                    break;
-                case Qt::Key_Comma:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(71, "kpcomma")
-                        : pressedButtons.insert(79, "comma");
-                    break;
-                case Qt::Key_Period:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(72, "kpperiod")
-                        : pressedButtons.insert(80, "period");
-                    break;
-                case Qt::Key_Enter:
-                    QApplication::keyboardModifiers() & Qt::KeypadModifier
-                        ? pressedButtons.insert(73, "kpenter")
-                        : pressedButtons.insert(81, "enter");
-                    break;
-                case Qt::Key_QuoteLeft:
-                    pressedButtons.insert(82, "grave");
-                    break;
-                case Qt::Key_AsciiTilde:
-                    pressedButtons.insert(83, "tilde");
-                    break;
-                case Qt::Key_Exclam:
-                    pressedButtons.insert(84, "exclamation");
-                    break;
-                case Qt::Key_At:
-                    pressedButtons.insert(85, "at");
-                    break;
-                case Qt::Key_NumberSign:
-                    pressedButtons.insert(86, "hash");
-                    break;
-                case Qt::Key_Dollar:
-                    pressedButtons.insert(87, "dollar");
-                    break;
-                case Qt::Key_Percent:
-                    pressedButtons.insert(88, "percent");
-                    break;
-                case Qt::Key_AsciiCircum:
-                    pressedButtons.insert(89, "caret");
-                    break;
-                case Qt::Key_Ampersand:
-                    pressedButtons.insert(90, "ampersand");
-                    break;
-                case Qt::Key_ParenLeft:
-                    pressedButtons.insert(91, "lparen");
-                    break;
-                case Qt::Key_ParenRight:
-                    pressedButtons.insert(92, "rparen");
-                    break;
-                case Qt::Key_BracketLeft:
-                    pressedButtons.insert(93, "lbracket");
-                    break;
-                case Qt::Key_BracketRight:
-                    pressedButtons.insert(94, "rbracket");
-                    break;
-                case Qt::Key_BraceLeft:
-                    pressedButtons.insert(95, "lbrace");
-                    break;
-                case Qt::Key_BraceRight:
-                    pressedButtons.insert(96, "rbrace");
-                    break;
-                case Qt::Key_Underscore:
-                    pressedButtons.insert(97, "underscore");
-                    break;
-                case Qt::Key_Backslash:
-                    pressedButtons.insert(98, "backslash");
-                    break;
-                case Qt::Key_Bar:
-                    pressedButtons.insert(99, "pipe");
-                    break;
-                case Qt::Key_Semicolon:
-                    pressedButtons.insert(100, "semicolon");
-                    break;
-                case Qt::Key_Colon:
-                    pressedButtons.insert(101, "colon");
-                    break;
-                case Qt::Key_Apostrophe:
-                    pressedButtons.insert(102, "apostrophe");
-                    break;
-                case Qt::Key_QuoteDbl:
-                    pressedButtons.insert(103, "quote");
-                    break;
-                case Qt::Key_Less:
-                    pressedButtons.insert(104, "less");
-                    break;
-                case Qt::Key_Greater:
-                    pressedButtons.insert(105, "greater");
-                    break;
-                case Qt::Key_Question:
-                    pressedButtons.insert(106, "question");
-                    break;
+                // symbols
+            case Qt::Key_Asterisk:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(66, "kpasterisk")
+                    : pressedButtons.insert(74, "asterisk");
+                break;
+            case Qt::Key_Minus:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(67, "kpminus")
+                    : pressedButtons.insert(75, "minus");
+                break;
+            case Qt::Key_Equal:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(68, "kpequals")
+                    : pressedButtons.insert(76, "equals");
+                break;
+            case Qt::Key_Plus:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(69, "kpplus")
+                    : pressedButtons.insert(77, "plus");
+                break;
+            case Qt::Key_Slash:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(70, "kpslash")
+                    : pressedButtons.insert(78, "slash");
+                break;
+            case Qt::Key_Comma:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(71, "kpcomma")
+                    : pressedButtons.insert(79, "comma");
+                break;
+            case Qt::Key_Period:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(72, "kpperiod")
+                    : pressedButtons.insert(80, "period");
+                break;
+            case Qt::Key_Enter:
+                QApplication::keyboardModifiers() & Qt::KeypadModifier
+                    ? pressedButtons.insert(73, "kpenter")
+                    : pressedButtons.insert(81, "enter");
+                break;
+            case Qt::Key_QuoteLeft:
+                pressedButtons.insert(82, "grave");
+                break;
+            case Qt::Key_AsciiTilde:
+                pressedButtons.insert(83, "tilde");
+                break;
+            case Qt::Key_Exclam:
+                pressedButtons.insert(84, "exclamation");
+                break;
+            case Qt::Key_At:
+                pressedButtons.insert(85, "at");
+                break;
+            case Qt::Key_NumberSign:
+                pressedButtons.insert(86, "hash");
+                break;
+            case Qt::Key_Dollar:
+                pressedButtons.insert(87, "dollar");
+                break;
+            case Qt::Key_Percent:
+                pressedButtons.insert(88, "percent");
+                break;
+            case Qt::Key_AsciiCircum:
+                pressedButtons.insert(89, "caret");
+                break;
+            case Qt::Key_Ampersand:
+                pressedButtons.insert(90, "ampersand");
+                break;
+            case Qt::Key_ParenLeft:
+                pressedButtons.insert(91, "lparen");
+                break;
+            case Qt::Key_ParenRight:
+                pressedButtons.insert(92, "rparen");
+                break;
+            case Qt::Key_BracketLeft:
+                pressedButtons.insert(93, "lbracket");
+                break;
+            case Qt::Key_BracketRight:
+                pressedButtons.insert(94, "rbracket");
+                break;
+            case Qt::Key_BraceLeft:
+                pressedButtons.insert(95, "lbrace");
+                break;
+            case Qt::Key_BraceRight:
+                pressedButtons.insert(96, "rbrace");
+                break;
+            case Qt::Key_Underscore:
+                pressedButtons.insert(97, "underscore");
+                break;
+            case Qt::Key_Backslash:
+                pressedButtons.insert(98, "backslash");
+                break;
+            case Qt::Key_Bar:
+                pressedButtons.insert(99, "pipe");
+                break;
+            case Qt::Key_Semicolon:
+                pressedButtons.insert(100, "semicolon");
+                break;
+            case Qt::Key_Colon:
+                pressedButtons.insert(101, "colon");
+                break;
+            case Qt::Key_Apostrophe:
+                pressedButtons.insert(102, "apostrophe");
+                break;
+            case Qt::Key_QuoteDbl:
+                pressedButtons.insert(103, "quote");
+                break;
+            case Qt::Key_Less:
+                pressedButtons.insert(104, "less");
+                break;
+            case Qt::Key_Greater:
+                pressedButtons.insert(105, "greater");
+                break;
+            case Qt::Key_Question:
+                pressedButtons.insert(106, "question");
+                break;
 
-                // special keys
-                case Qt::Key_Print:
-                    pressedButtons.insert(107, "printscreen");
-                    break;
-                case Qt::Key_ScrollLock:
-                    pressedButtons.insert(108, "scrolllock");
-                    break;
-                case Qt::Key_Pause:
-                    pressedButtons.insert(109, "pausebreak");
-                    break;
-                case Qt::Key_Backspace:
-                    pressedButtons.insert(110, "backspace");
-                    break;
-                case Qt::Key_Insert:
-                    pressedButtons.insert(111, "insert");
-                    break;
-                case Qt::Key_Delete:
-                    pressedButtons.insert(112, "delete");
-                    break;
-                case Qt::Key_Home:
-                    pressedButtons.insert(113, "home");
-                    break;
-                case Qt::Key_End:
-                    pressedButtons.insert(114, "end");
-                    break;
-                case Qt::Key_PageUp:
-                    pressedButtons.insert(115, "pgup");
-                    break;
-                case Qt::Key_PageDown:
-                    pressedButtons.insert(116, "pgdown");
-                    break;
-                case Qt::Key_Tab:
-                    pressedButtons.insert(117, "tab");
-                    break;
-                case Qt::Key_CapsLock:
-                    pressedButtons.insert(118, "capslock");
-                    break;
-                case Qt::Key_Return:
-                    pressedButtons.insert(119, "enter");
-                    break;
-                case Qt::Key_Space:
-                    pressedButtons.insert(120, "space");
-                    break;
-                case Qt::Key_Up:
-                    pressedButtons.insert(121, "up");
-                    break;
-                case Qt::Key_Down:
-                    pressedButtons.insert(122, "down");
-                    break;
-                case Qt::Key_Left:
-                    pressedButtons.insert(123, "left");
-                    break;
-                case Qt::Key_Right:
-                    pressedButtons.insert(124, "right");
-                    break;
-                case Qt::Key_Escape:
-                    pressedButtons.insert(125, "escape");
-                    break;
+            // special keys
+            case Qt::Key_Print:
+                pressedButtons.insert(107, "printscreen");
+                break;
+            case Qt::Key_ScrollLock:
+                pressedButtons.insert(108, "scrolllock");
+                break;
+            case Qt::Key_Pause:
+                pressedButtons.insert(109, "pausebreak");
+                break;
+            case Qt::Key_Backspace:
+                pressedButtons.insert(110, "backspace");
+                break;
+            case Qt::Key_Insert:
+                pressedButtons.insert(111, "insert");
+                break;
+            case Qt::Key_Delete:
+                pressedButtons.insert(112, "delete");
+                break;
+            case Qt::Key_Home:
+                pressedButtons.insert(113, "home");
+                break;
+            case Qt::Key_End:
+                pressedButtons.insert(114, "end");
+                break;
+            case Qt::Key_PageUp:
+                pressedButtons.insert(115, "pgup");
+                break;
+            case Qt::Key_PageDown:
+                pressedButtons.insert(116, "pgdown");
+                break;
+            case Qt::Key_Tab:
+                pressedButtons.insert(117, "tab");
+                break;
+            case Qt::Key_CapsLock:
+                pressedButtons.insert(118, "capslock");
+                break;
+            case Qt::Key_Return:
+                pressedButtons.insert(119, "enter");
+                break;
+            case Qt::Key_Space:
+                pressedButtons.insert(120, "space");
+                break;
+            case Qt::Key_Up:
+                pressedButtons.insert(121, "up");
+                break;
+            case Qt::Key_Down:
+                pressedButtons.insert(122, "down");
+                break;
+            case Qt::Key_Left:
+                pressedButtons.insert(123, "left");
+                break;
+            case Qt::Key_Right:
+                pressedButtons.insert(124, "right");
+                break;
+            case Qt::Key_Escape:
+                pressedButtons.insert(125, "escape");
+                break;
+            default:
+                break;
+            }
 
-                default:
-                    break;
-                }
-                return true;
+            return true;
         }
     }
 

--- a/src/qt_gui/hotkeys.h
+++ b/src/qt_gui/hotkeys.h
@@ -7,6 +7,7 @@
 #include <SDL3/SDL_gamepad.h>
 
 #include "ipc/ipc_client.h"
+#include "right_click_button.h"
 
 #ifdef _WIN32
 #define LCTRL_KEY 29
@@ -32,13 +33,13 @@ public:
 
 private Q_SLOTS:
     void processSDLEvents(int Type, int Input, int Value);
-    void StartTimer(QPushButton*& button, bool isPad);
+    void StartTimer(QRightClickButton*& button, bool isPad);
     void SaveHotkeys(bool CloseOnSave);
     void SetDefault();
 
 private:
     bool eventFilter(QObject* obj, QEvent* event) override;
-    void CheckMapping(QPushButton*& button);
+    void CheckMapping(QRightClickButton*& button);
     void DisableMappingButtons();
     void EnableMappingButtons();
     void LoadHotkeys();
@@ -59,14 +60,14 @@ private:
     int gamepad_count;
     QString mapping;
     QTimer* timer;
-    QPushButton* MappingButton;
+    QRightClickButton* MappingButton;
     SDL_Gamepad* h_gamepad = nullptr;
     SDL_JoystickID* h_gamepads;
 
     // use QMap instead of QSet to maintain order of inserted strings
     QMap<int, QString> pressedButtons;
-    QList<QPushButton*> PadButtonsList;
-    QList<QPushButton*> KBButtonsList;
+    QList<QRightClickButton*> PadButtonsList;
+    QList<QRightClickButton*> KBButtonsList;
     QFuture<void> Polling;
 
     Ui::Hotkeys* ui;

--- a/src/qt_gui/hotkeys.ui
+++ b/src/qt_gui/hotkeys.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+<!-- SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
      SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>Hotkeys</class>
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>987</width>
-    <height>549</height>
+    <height>641</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
      <x>3</x>
      <y>2</y>
      <width>981</width>
-     <height>541</height>
+     <height>601</height>
     </rect>
    </property>
    <property name="widgetResizable">
@@ -36,7 +36,7 @@
       <x>0</x>
       <y>0</y>
       <width>979</width>
-      <height>539</height>
+      <height>599</height>
      </rect>
     </property>
     <widget class="QWidget" name="verticalLayoutWidget_3">
@@ -45,7 +45,7 @@
        <x>3</x>
        <y>7</y>
        <width>971</width>
-       <height>532</height>
+       <height>587</height>
       </rect>
      </property>
      <layout class="QVBoxLayout" name="HotkeysLayout">
@@ -86,7 +86,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QPushButton" name="fpsButtonPad">
+            <widget class="QRightClickButton" name="fpsButtonPad">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -111,7 +111,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
-            <widget class="QPushButton" name="quitButtonPad">
+            <widget class="QRightClickButton" name="quitButtonPad">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -136,7 +136,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_6">
            <item>
-            <widget class="QPushButton" name="reloadButtonPad">
+            <widget class="QRightClickButton" name="reloadButtonPad">
              <property name="text">
               <string>unmapped</string>
              </property>
@@ -162,7 +162,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
-            <widget class="QPushButton" name="fullscreenButtonPad">
+            <widget class="QRightClickButton" name="fullscreenButtonPad">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -187,7 +187,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
-            <widget class="QPushButton" name="pauseButtonPad">
+            <widget class="QRightClickButton" name="pauseButtonPad">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -251,7 +251,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_7">
            <item>
-            <widget class="QPushButton" name="fpsButtonKB">
+            <widget class="QRightClickButton" name="fpsButtonKB">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -276,7 +276,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
            <item>
-            <widget class="QPushButton" name="quitButtonKB">
+            <widget class="QRightClickButton" name="quitButtonKB">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -301,7 +301,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_11">
            <item>
-            <widget class="QPushButton" name="reloadButtonKB">
+            <widget class="QRightClickButton" name="reloadButtonKB">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -330,7 +330,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
            <item>
-            <widget class="QPushButton" name="fullscreenButtonKB">
+            <widget class="QRightClickButton" name="fullscreenButtonKB">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -355,7 +355,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_10">
            <item>
-            <widget class="QPushButton" name="pauseButtonKB">
+            <widget class="QRightClickButton" name="pauseButtonKB">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -380,7 +380,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <item>
-            <widget class="QPushButton" name="renderdocButton">
+            <widget class="QRightClickButton" name="renderdocButton">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -409,7 +409,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
            <item>
-            <widget class="QPushButton" name="mouseJoystickButton">
+            <widget class="QRightClickButton" name="mouseJoystickButton">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -434,7 +434,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_14">
            <item>
-            <widget class="QPushButton" name="mouseGyroButton">
+            <widget class="QRightClickButton" name="mouseGyroButton">
              <property name="focusPolicy">
               <enum>Qt::FocusPolicy::NoFocus</enum>
              </property>
@@ -484,25 +484,24 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+       <widget class="QLabel" name="tipLabel_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+          <bold>true</bold>
+         </font>
         </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QDialogButtonBox" name="buttonBox">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+        <property name="text">
+         <string>Tip: Unmap inputs with right-click</string>
         </property>
-        <property name="standardButtons">
-         <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -510,7 +509,30 @@
     </widget>
    </widget>
   </widget>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>610</y>
+     <width>969</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Orientation::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+   </property>
+  </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QRightClickButton</class>
+   <extends>QPushButton</extends>
+   <header>src/qt_gui/right_click_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -5,6 +5,7 @@
 
 #include "game_info.h"
 #include "ipc/ipc_client.h"
+#include "right_click_button.h"
 
 // macros > declaring constants
 // also, we were only using one counterpart
@@ -36,8 +37,8 @@ signals:
 private Q_SLOTS:
     void SaveKBMConfig(bool CloseOnSave);
     void SetDefault();
-    void CheckMapping(QPushButton*& button);
-    void StartTimer(QPushButton*& button);
+    void CheckMapping(QRightClickButton*& button);
+    void StartTimer(QRightClickButton*& button);
     void onHelpClicked();
 
 private:
@@ -63,8 +64,8 @@ private:
     QString mapping;
     int MappingTimer;
     QTimer* timer;
-    QPushButton* MappingButton;
-    QList<QPushButton*> ButtonsList;
+    QRightClickButton* MappingButton;
+    QList<QRightClickButton*> ButtonsList;
     std::string config_id;
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",

--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>1235</width>
-    <height>836</height>
+    <height>874</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -57,7 +57,7 @@
         <x>0</x>
         <y>0</y>
         <width>1207</width>
-        <height>827</height>
+        <height>860</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -86,7 +86,7 @@
               <bool>true</bool>
              </property>
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -156,7 +156,7 @@
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_4">
                     <item>
-                     <widget class="QPushButton" name="DpadUpButton">
+                     <widget class="QRightClickButton" name="DpadUpButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -201,7 +201,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="DpadLeftButton">
+                    <widget class="QRightClickButton" name="DpadLeftButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -241,7 +241,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="DpadRightButton">
+                    <widget class="QRightClickButton" name="DpadRightButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -292,7 +292,7 @@
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_3">
                     <item>
-                     <widget class="QPushButton" name="DpadDownButton">
+                     <widget class="QRightClickButton" name="DpadDownButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -329,14 +329,14 @@
            <item>
             <widget class="QGroupBox" name="LeftStickDeadZoneGB">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
              <property name="maximumSize">
               <size>
-               <width>344</width>
+               <width>16777215</width>
                <height>16777215</height>
               </size>
              </property>
@@ -345,7 +345,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_15">
               <item>
-               <widget class="QPushButton" name="LHalfButton">
+               <widget class="QRightClickButton" name="LHalfButton">
                 <property name="focusPolicy">
                  <enum>Qt::FocusPolicy::NoFocus</enum>
                 </property>
@@ -372,7 +372,7 @@
            <item>
             <widget class="QGroupBox" name="gb_left_stick">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -442,7 +442,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_10">
                     <item>
-                     <widget class="QPushButton" name="LStickUpButton">
+                     <widget class="QRightClickButton" name="LStickUpButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -487,7 +487,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="LStickLeftButton">
+                    <widget class="QRightClickButton" name="LStickLeftButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -509,7 +509,7 @@
                   </property>
                   <property name="maximumSize">
                    <size>
-                    <width>179</width>
+                    <width>16777215</width>
                     <height>16777215</height>
                    </size>
                   </property>
@@ -533,7 +533,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="LStickRightButton">
+                    <widget class="QRightClickButton" name="LStickRightButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -584,7 +584,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_8">
                     <item>
-                     <widget class="QPushButton" name="LStickDownButton">
+                     <widget class="QRightClickButton" name="LStickDownButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -767,7 +767,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="L1Button">
+                   <widget class="QRightClickButton" name="L1Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -819,7 +819,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="L2Button">
+                   <widget class="QRightClickButton" name="L2Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -945,7 +945,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="OptionsButton">
+                   <widget class="QRightClickButton" name="OptionsButton">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1001,7 +1001,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="R1Button">
+                   <widget class="QRightClickButton" name="R1Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1053,7 +1053,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="R2Button">
+                   <widget class="QRightClickButton" name="R2Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1162,7 +1162,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="L3Button">
+                   <widget class="QRightClickButton" name="L3Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1190,7 +1190,7 @@
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_17">
                   <item>
-                   <widget class="QPushButton" name="TouchpadLeftButton">
+                   <widget class="QRightClickButton" name="TouchpadLeftButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1259,7 +1259,7 @@
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_11">
                   <item>
-                   <widget class="QPushButton" name="TouchpadCenterButton">
+                   <widget class="QRightClickButton" name="TouchpadCenterButton">
                     <property name="text">
                      <string>unmapped</string>
                     </property>
@@ -1306,7 +1306,7 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QPushButton" name="R3Button">
+                   <widget class="QRightClickButton" name="R3Button">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1346,7 +1346,7 @@
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_9">
                   <item>
-                   <widget class="QPushButton" name="TouchpadRightButton">
+                   <widget class="QRightClickButton" name="TouchpadRightButton">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -1599,7 +1599,7 @@
            <item>
             <widget class="QGroupBox" name="gb_face_buttons">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -1663,7 +1663,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_3">
                     <item>
-                     <widget class="QPushButton" name="TriangleButton">
+                     <widget class="QRightClickButton" name="TriangleButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -1708,7 +1708,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="SquareButton">
+                    <widget class="QRightClickButton" name="SquareButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -1748,7 +1748,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="CircleButton">
+                    <widget class="QRightClickButton" name="CircleButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -1799,7 +1799,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_5">
                     <item>
-                     <widget class="QPushButton" name="CrossButton">
+                     <widget class="QRightClickButton" name="CrossButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -1836,14 +1836,14 @@
            <item>
             <widget class="QGroupBox" name="RightStickDeadZoneGB">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
              <property name="maximumSize">
               <size>
-               <width>344</width>
+               <width>16777215</width>
                <height>16777215</height>
               </size>
              </property>
@@ -1852,7 +1852,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_13">
               <item>
-               <widget class="QPushButton" name="RHalfButton">
+               <widget class="QRightClickButton" name="RHalfButton">
                 <property name="focusPolicy">
                  <enum>Qt::FocusPolicy::NoFocus</enum>
                 </property>
@@ -1879,7 +1879,7 @@
            <item>
             <widget class="QGroupBox" name="gb_right_stick">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -1949,7 +1949,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_7">
                     <item>
-                     <widget class="QPushButton" name="RStickUpButton">
+                     <widget class="QRightClickButton" name="RStickUpButton">
                       <property name="minimumSize">
                        <size>
                         <width>0</width>
@@ -2000,7 +2000,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="RStickLeftButton">
+                    <widget class="QRightClickButton" name="RStickLeftButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -2040,7 +2040,7 @@
                     <number>5</number>
                    </property>
                    <item>
-                    <widget class="QPushButton" name="RStickRightButton">
+                    <widget class="QRightClickButton" name="RStickRightButton">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
@@ -2091,7 +2091,7 @@
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_6">
                     <item>
-                     <widget class="QPushButton" name="RStickDownButton">
+                     <widget class="QRightClickButton" name="RStickDownButton">
                       <property name="focusPolicy">
                        <enum>Qt::FocusPolicy::NoFocus</enum>
                       </property>
@@ -2118,17 +2118,46 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Tip: Unmap inputs with right-click</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+       </property>
+       <property name="centerButtons">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QRightClickButton</class>
+   <extends>QPushButton</extends>
+   <header>src/qt_gui/right_click_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../shadps4.qrc"/>
  </resources>

--- a/src/qt_gui/right_click_button.cpp
+++ b/src/qt_gui/right_click_button.cpp
@@ -5,11 +5,9 @@
 
 #include "right_click_button.h"
 
-QRightClickButton::QRightClickButton(QWidget *parent) :
-    QPushButton(parent) {
-}
+QRightClickButton::QRightClickButton(QWidget* parent) : QPushButton(parent) {}
 
-void QRightClickButton::mousePressEvent(QMouseEvent *e) {
+void QRightClickButton::mousePressEvent(QMouseEvent* e) {
     if (e->button() == Qt::RightButton) {
         emit rightClicked();
     } else {

--- a/src/qt_gui/right_click_button.cpp
+++ b/src/qt_gui/right_click_button.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <QMouseEvent>
+
+#include "right_click_button.h"
+
+QRightClickButton::QRightClickButton(QWidget *parent) :
+    QPushButton(parent) {
+}
+
+void QRightClickButton::mousePressEvent(QMouseEvent *e) {
+    if (e->button() == Qt::RightButton) {
+        emit rightClicked();
+    } else {
+        QPushButton::mousePressEvent(e);
+    }
+}

--- a/src/qt_gui/right_click_button.h
+++ b/src/qt_gui/right_click_button.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPushButton>
+
+class QRightClickButton : public QPushButton {
+    Q_OBJECT
+
+public:
+    explicit QRightClickButton(QWidget *parent = 0);
+
+public slots:
+    void mousePressEvent(QMouseEvent *e);
+
+signals:
+    void rightClicked();
+};

--- a/src/qt_gui/right_click_button.h
+++ b/src/qt_gui/right_click_button.h
@@ -10,10 +10,10 @@ class QRightClickButton : public QPushButton {
     Q_OBJECT
 
 public:
-    explicit QRightClickButton(QWidget *parent = 0);
+    explicit QRightClickButton(QWidget* parent = 0);
 
 public slots:
-    void mousePressEvent(QMouseEvent *e);
+    void mousePressEvent(QMouseEvent* e);
 
 signals:
     void rightClicked();


### PR DESCRIPTION
1. Kbm/controller: Allow horizontal resizing (vertical already allowed) , fix elements accordingly
2. Clear bindings using right click (when not awaiting inputs) instead of escape, add labels to inform users of this function
3. Kbm/hotkeys: Make escape bindable
4. Kbm: Broaden event filter scope so that mouse clicks are captured as remapping inputs even when hovering over a button