### PR TITLE
Cli open targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,10 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/settings_dialog.cpp
            src/qt_gui/settings_dialog.h
            src/qt_gui/settings_dialog.ui
+           src/qt_gui/settings_tab_dialog.cpp
+           src/qt_gui/settings_tab_dialog.h
+           src/qt_gui/settings_tab_targets.cpp
+           src/qt_gui/settings_tab_targets.h
            src/qt_gui/gui_settings.cpp
            src/qt_gui/gui_settings.h
            src/qt_gui/settings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/background_music_player.h
            src/qt_gui/cheats_patches.cpp
            src/qt_gui/cheats_patches.h
+           src/qt_gui/cli_options.cpp
+           src/qt_gui/cli_options.h
            src/qt_gui/compatibility_info.cpp
            src/qt_gui/compatibility_info.h
            src/qt_gui/control_settings.cpp
@@ -380,6 +382,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/create_shortcut.h
            src/qt_gui/right_click_button.cpp
            src/qt_gui/right_click_button.h
+           src/qt_gui/open_targets.cpp
+           src/qt_gui/open_targets.h
            ${RESOURCE_FILES}
            ${TRANSLATIONS}
            ${UPDATER}

--- a/src/qt_gui/cli_options.cpp
+++ b/src/qt_gui/cli_options.cpp
@@ -68,12 +68,11 @@ ParseResult ParseOptions(const QStringList& arguments) {
     parser.addHelpOption();
 
     const QCommandLineOption open_option("open", "Open a UI target and exit when closed.",
-                                        "target");
-    const QCommandLineOption game_option(QStringList{"g", "game"},
-                                         "Game path (eboot.bin or directory containing it).",
-                                         "path");
-    const QCommandLineOption emulator_option(QStringList{"e", "emulator"},
-                                             "Emulator name or path.", "name_or_path");
+                                         "target");
+    const QCommandLineOption game_option(
+        QStringList{"g", "game"}, "Game path (eboot.bin or directory containing it).", "path");
+    const QCommandLineOption emulator_option(QStringList{"e", "emulator"}, "Emulator name or path.",
+                                             "name_or_path");
     const QCommandLineOption default_emulator_option("d", "Alias for '--emulator default'.");
     const QCommandLineOption show_gui_option(QStringList{"s", "show-gui"},
                                              "Show the GUI after launch.");

--- a/src/qt_gui/cli_options.cpp
+++ b/src/qt_gui/cli_options.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+
+#include "common/path_util.h"
+#include "qt_gui/cli_options.h"
+
+namespace QtGui::Cli {
+
+namespace {
+
+struct ArgumentSplit {
+    QStringList option_args;
+    QStringList emulator_args;
+    bool has_separator = false;
+};
+
+ArgumentSplit SplitArguments(const QStringList& arguments) {
+    ArgumentSplit split;
+    split.option_args = arguments;
+    const int separator_index = split.option_args.indexOf("--");
+    if (separator_index < 0) {
+        return split;
+    }
+
+    split.has_separator = true;
+    split.emulator_args = split.option_args.mid(separator_index + 1);
+    split.option_args = split.option_args.mid(0, separator_index);
+    return split;
+}
+
+std::optional<std::filesystem::path> NormalizeGamePath(const QString& path) {
+    if (path.isEmpty()) {
+        return std::nullopt;
+    }
+
+    std::filesystem::path fs_path;
+#ifdef _WIN32
+    fs_path = std::filesystem::path(path.toStdWString());
+#else
+    fs_path = std::filesystem::path(path.toStdString());
+#endif
+    return Common::FS::NormalizeGamePathToEboot(fs_path);
+}
+
+QString PathToQString(const std::filesystem::path& path) {
+#ifdef _WIN32
+    return QString::fromStdWString(path.wstring());
+#else
+    return QString::fromStdString(path.string());
+#endif
+}
+
+} // namespace
+
+ParseResult ParseOptions(const QStringList& arguments) {
+    ParseResult result;
+    result.options.has_command_line_argument = arguments.size() > 1;
+
+    const ArgumentSplit split = SplitArguments(arguments);
+    result.options.emulator_args = split.emulator_args;
+    result.options.has_emulator_args_separator = split.has_separator;
+
+    QCommandLineParser parser;
+    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    parser.addHelpOption();
+
+    const QCommandLineOption open_option("open", "Open a UI target and exit when closed.",
+                                        "target");
+    const QCommandLineOption game_option(QStringList{"g", "game"},
+                                         "Game path (eboot.bin or directory containing it).",
+                                         "path");
+    const QCommandLineOption emulator_option(QStringList{"e", "emulator"},
+                                             "Emulator name or path.", "name_or_path");
+    const QCommandLineOption default_emulator_option("d", "Alias for '--emulator default'.");
+    const QCommandLineOption show_gui_option(QStringList{"s", "show-gui"},
+                                             "Show the GUI after launch.");
+    const QCommandLineOption no_ipc_option(QStringList{"i", "no-ipc"}, "Disable IPC.");
+
+    parser.addOption(open_option);
+    parser.addOption(game_option);
+    parser.addOption(emulator_option);
+    parser.addOption(default_emulator_option);
+    parser.addOption(show_gui_option);
+    parser.addOption(no_ipc_option);
+
+    if (!parser.parse(split.option_args)) {
+        result.error_message = parser.errorText();
+        return result;
+    }
+
+    if (parser.isSet("help")) {
+        result.show_help = true;
+        result.help_text = parser.helpText();
+        result.success = true;
+        return result;
+    }
+
+    if (parser.isSet(default_emulator_option) && parser.isSet(emulator_option)) {
+        result.error_message = "--emulator and -d cannot be used together.";
+        return result;
+    }
+
+    result.options.show_gui = parser.isSet(show_gui_option);
+    result.options.no_ipc = parser.isSet(no_ipc_option);
+
+    if (parser.isSet(emulator_option)) {
+        result.options.emulator = parser.value(emulator_option).toStdString();
+        result.options.has_emulator_argument = true;
+    } else if (parser.isSet(default_emulator_option)) {
+        result.options.emulator = "default";
+        result.options.has_emulator_argument = true;
+    }
+
+    if (parser.isSet(game_option)) {
+        result.options.game_arg = parser.value(game_option);
+        auto normalized = NormalizeGamePath(result.options.game_arg);
+        if (!normalized) {
+            result.error_message = "Invalid game path provided.";
+            return result;
+        }
+        result.options.normalized_game_path = normalized;
+        result.options.game_arg = PathToQString(*normalized);
+    }
+
+    if (parser.isSet(open_option)) {
+        result.options.open_target_specified = true;
+        result.options.open_target = parser.value(open_option);
+    }
+
+    if (result.options.open_target_specified) {
+        if (result.options.has_emulator_argument || result.options.show_gui ||
+            result.options.no_ipc || !result.options.emulator_args.isEmpty()) {
+            result.error_message =
+                "--open cannot be combined with emulator launch options or '--' arguments.";
+            return result;
+        }
+    }
+
+    if (!result.options.open_target_specified && result.options.has_command_line_argument &&
+        !result.options.has_emulator_argument) {
+        result.error_message = "Please provide a name or path for the emulator core.";
+        return result;
+    }
+
+    if (!result.options.open_target_specified && !result.options.has_emulator_argument &&
+        !result.options.game_arg.isEmpty()) {
+        result.error_message = "--game requires --emulator (or -d).";
+        return result;
+    }
+
+    result.success = true;
+    return result;
+}
+
+} // namespace QtGui::Cli

--- a/src/qt_gui/cli_options.h
+++ b/src/qt_gui/cli_options.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include <QString>
+#include <QStringList>
+
+namespace QtGui::Cli {
+
+struct Options {
+    bool has_command_line_argument = false;
+    bool has_emulator_argument = false;
+    bool show_gui = false;
+    bool no_ipc = false;
+    bool open_target_specified = false;
+    bool has_emulator_args_separator = false;
+    std::string emulator;
+    QString game_arg;
+    QString open_target;
+    QStringList emulator_args;
+    std::optional<std::filesystem::path> normalized_game_path;
+};
+
+struct ParseResult {
+    bool success = false;
+    bool show_help = false;
+    QString error_message;
+    QString help_text;
+    Options options;
+};
+
+ParseResult ParseOptions(const QStringList& arguments);
+
+} // namespace QtGui::Cli

--- a/src/qt_gui/elf_viewer.h
+++ b/src/qt_gui/elf_viewer.h
@@ -3,7 +3,13 @@
 
 #pragma once
 
+#include <QColor>
 #include <QFileDialog>
+#include <QGraphicsDropShadowEffect>
+#include <QLabel>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QVBoxLayout>
 
 #include "core/file_format/elf.h"
 #include "game_list_frame.h"

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -403,7 +403,7 @@ public:
 
         if (selected == &openTrophyViewer) {
             UiOpenTargets::OpenTargetContext context{};
-            context.gui_settings = m_gui_settings;
+            context.gui_settings_shared = m_gui_settings;
             context.compat_info = m_compat_info;
             context.ipc_client = m_ipc_client;
             context.game_info = std::make_shared<GameInfoClass>();
@@ -418,7 +418,7 @@ public:
 
         if (selected == &gameConfigConfigure || selected == &gameConfigCreate) {
             UiOpenTargets::OpenTargetContext context{};
-            context.gui_settings = m_gui_settings;
+            context.gui_settings_shared = m_gui_settings;
             context.compat_info = m_compat_info;
             context.ipc_client = m_ipc_client;
             context.game_info = std::make_shared<GameInfoClass>();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -27,9 +27,9 @@
 #include "ipc/ipc_client.h"
 #include "kbm_gui.h"
 #include "main_window.h"
+#include "open_targets.h"
 #include "settings_dialog.h"
 #include "skylander_dialog.h"
-#include "open_targets.h"
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -70,9 +70,8 @@ bool MainWindow::Init(InitMode init_mode) {
             window_title = fmt::format("shadPS4QtLauncher v{} {} {}", Common::g_scm_app_version,
                                        Common::g_scm_branch, Common::g_scm_desc);
         } else {
-            window_title =
-                fmt::format("shadPS4QtLauncher v{} {}/{} {}", Common::g_scm_app_version,
-                            remote_host, Common::g_scm_branch, Common::g_scm_desc);
+            window_title = fmt::format("shadPS4QtLauncher v{} {}/{} {}", Common::g_scm_app_version,
+                                       remote_host, Common::g_scm_branch, Common::g_scm_desc);
         }
         setWindowTitle(QString::fromStdString(window_title));
     }
@@ -109,7 +108,7 @@ UiOpenTargets::OpenTargetContext MainWindow::BuildOpenTargetContext(
     QWidget* parent, bool attach_parent_destroy, bool is_game_specific,
     const std::string& game_serial) const {
     UiOpenTargets::OpenTargetContext context{};
-    context.gui_settings = m_gui_settings;
+    context.gui_settings_shared = m_gui_settings;
     context.compat_info = m_compat_info;
     context.ipc_client = m_ipc_client;
     context.game_info = m_game_info;
@@ -564,21 +563,17 @@ void MainWindow::CreateConnects() {
                 });
     };
 
-    connect(ui->configureAct, &QAction::triggered, this, [open_settings_dialog]() {
-        open_settings_dialog();
-    });
+    connect(ui->configureAct, &QAction::triggered, this,
+            [open_settings_dialog]() { open_settings_dialog(); });
 
-    connect(ui->settingsButton, &QPushButton::clicked, this, [open_settings_dialog]() {
-        open_settings_dialog();
-    });
+    connect(ui->settingsButton, &QPushButton::clicked, this,
+            [open_settings_dialog]() { open_settings_dialog(); });
 
-    connect(ui->controllerButton, &QPushButton::clicked, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::Controllers);
-    });
+    connect(ui->controllerButton, &QPushButton::clicked, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::Controllers); });
 
-    connect(ui->keyboardButton, &QPushButton::clicked, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::KeyboardMouse);
-    });
+    connect(ui->keyboardButton, &QPushButton::clicked, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::KeyboardMouse); });
 
     connect(ui->versionManagerButton, &QPushButton::clicked, this, [this, open_target]() {
         auto result = open_target(UiOpenTargets::TargetId::VersionManager);
@@ -599,9 +594,8 @@ void MainWindow::CreateConnects() {
     connect(ui->aboutAct, &QAction::triggered, this,
             [open_target]() { open_target(UiOpenTargets::TargetId::About); });
 
-    connect(ui->configureHotkeys, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::Hotkeys);
-    });
+    connect(ui->configureHotkeys, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::Hotkeys); });
 
     connect(ui->setIconSizeTinyAct, &QAction::triggered, this, [this]() {
         if (isTableList) {
@@ -703,9 +697,8 @@ void MainWindow::CreateConnects() {
     });
 
     // Cheats/Patches Download.
-    connect(ui->downloadCheatsPatchesAct, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::CheatsPatchesDownload);
-    });
+    connect(ui->downloadCheatsPatchesAct, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::CheatsPatchesDownload); });
 
     // Dump game list.
     connect(ui->dumpGameListAct, &QAction::triggered, this, [&] {
@@ -743,24 +736,20 @@ void MainWindow::CreateConnects() {
             &ElfViewer::OpenElfFolder);
 
     // Trophy Viewer
-    connect(ui->trophyViewerAct, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::TrophyViewer);
-    });
+    connect(ui->trophyViewerAct, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::TrophyViewer); });
 
     // Manage Skylanders
-    connect(ui->skylanderPortalAction, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::SkylanderPortal);
-    });
+    connect(ui->skylanderPortalAction, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::SkylanderPortal); });
 
     // Manage Infinity Figures
-    connect(ui->infinityFiguresAction, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::InfinityBase);
-    });
+    connect(ui->infinityFiguresAction, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::InfinityBase); });
 
     // Manage Dimensions Toypad
-    connect(ui->dimensionsToypadAction, &QAction::triggered, this, [open_target]() {
-        open_target(UiOpenTargets::TargetId::DimensionsToypad);
-    });
+    connect(ui->dimensionsToypadAction, &QAction::triggered, this,
+            [open_target]() { open_target(UiOpenTargets::TargetId::DimensionsToypad); });
 
     // Themes
     connect(ui->setThemeDark, &QAction::triggered, &m_window_themes, [this]() {
@@ -985,9 +974,8 @@ void MainWindow::BootGame() {
 
 void MainWindow::InstallDirectory() {
     auto context = BuildOpenTargetContext(this);
-    auto result =
-        UiOpenTargets::OpenTarget(UiOpenTargets::TargetId::GameInstall, context,
-                                  UiOpenTargets::OpenBehaviorForUi());
+    auto result = UiOpenTargets::OpenTarget(UiOpenTargets::TargetId::GameInstall, context,
+                                            UiOpenTargets::OpenBehaviorForUi());
     if (result.success) {
         RefreshGameTable();
     }
@@ -1234,7 +1222,7 @@ void MainWindow::StartEmulator(std::filesystem::path path, QStringList args) {
     QString selectedVersion = m_gui_settings->GetValue(gui::vm_versionSelected).toString();
     if (selectedVersion.isEmpty()) {
         QMessageBox::warning(this, tr("No Version Selected"),
-        // clang-format off
+                             // clang-format off
         tr("No emulator version was selected.\n"
            "The Version Manager menu will then open.\n"
            "Select an emulator version from the right panel."));

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <QAction>
 #include <QActionGroup>
 #include <QDragEnterEvent>
+#include <QMainWindow>
 #include <QProcess>
 #include <QTranslator>
 
@@ -22,6 +24,7 @@
 #include "ipc/ipc_client.h"
 #include "main_window_themes.h"
 #include "main_window_ui.h"
+#include "open_targets.h"
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -29,9 +32,14 @@ signals:
     void WindowResized(QResizeEvent* event);
 
 public:
+    enum class InitMode {
+        Full,
+        Headless,
+    };
+
     explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
-    bool Init();
+    bool Init(InitMode init_mode = InitMode::Full);
     void InstallDirectory();
     void StartGame();
     void StartGameWithArgs(QStringList args = {});
@@ -42,6 +50,10 @@ public:
     void StopGame();
     void RestartGame();
     void LoadVersionComboBox();
+    UiOpenTargets::OpenTargetContext BuildOpenTargetContext(
+        QWidget* parent = nullptr, bool attach_parent_destroy = false,
+        bool is_game_specific = false, const std::string& game_serial = "") const;
+    const std::string& GetRunningGameSerial() const;
     bool showLabels;
     std::shared_ptr<IpcClient> m_ipc_client = std::make_shared<IpcClient>();
 

--- a/src/qt_gui/open_targets.cpp
+++ b/src/qt_gui/open_targets.cpp
@@ -1,0 +1,585 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <vector>
+
+#include <QCoreApplication>
+#include <QDialog>
+#include <QEventLoop>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "common/config.h"
+#include "common/path_util.h"
+#include "core/emulator_state.h"
+#include "ipc/ipc_client.h"
+#include "qt_gui/about_dialog.h"
+#include "qt_gui/cheats_patches.h"
+#include "qt_gui/compatibility_info.h"
+#include "qt_gui/control_settings.h"
+#include "qt_gui/dimensions_dialog.h"
+#include "qt_gui/game_info.h"
+#include "qt_gui/game_install_dialog.h"
+#include "qt_gui/hotkeys.h"
+#include "qt_gui/infinity_dialog.h"
+#include "qt_gui/kbm_gui.h"
+#include "qt_gui/open_targets.h"
+#include "qt_gui/settings_dialog.h"
+#include "qt_gui/settings_tab_dialog.h"
+#include "qt_gui/settings_tab_targets.h"
+#include "qt_gui/skylander_dialog.h"
+#include "qt_gui/trophy_viewer.h"
+#include "qt_gui/version_dialog.h"
+
+namespace UiOpenTargets {
+
+namespace {
+
+struct TargetEntry {
+    QString name;
+    TargetId id;
+};
+
+const std::vector<TargetEntry>& TargetEntries() {
+    static const std::vector<TargetEntry> entries = {
+        {"settings", TargetId::Settings},
+        {"version_manager", TargetId::VersionManager},
+        {"controllers", TargetId::Controllers},
+        {"keyboard_mouse", TargetId::KeyboardMouse},
+        {"hotkeys", TargetId::Hotkeys},
+        {"about", TargetId::About},
+        {"game_install", TargetId::GameInstall},
+        {"cheats_patches_download", TargetId::CheatsPatchesDownload},
+        {"trophy_viewer", TargetId::TrophyViewer},
+        {"skylander_portal", TargetId::SkylanderPortal},
+        {"infinity_base", TargetId::InfinityBase},
+        {"dimensions_toypad", TargetId::DimensionsToypad},
+    };
+    return entries;
+}
+
+QString NormalizeTargetString(const QString& target) {
+    return target.trimmed().toLower();
+}
+
+QStringList CollectSettingsTabTargets(SettingsDialog* dialog) {
+    QStringList results;
+    if (!dialog) {
+        return results;
+    }
+
+    QTabWidget* tab_widget = dialog->GetTabWidget();
+    if (!tab_widget) {
+        return results;
+    }
+
+    for (int i = 0; i < tab_widget->count(); ++i) {
+        if (!tab_widget->isTabVisible(i)) {
+            continue;
+        }
+        QWidget* page = tab_widget->widget(i);
+        if (!page) {
+            continue;
+        }
+        const QString target = QtGui::SettingsTabs::BuildTabTarget(page->objectName());
+        if (!target.isEmpty()) {
+            results.append(target);
+        }
+    }
+
+    results.sort();
+    return results;
+}
+
+std::optional<QString> ResolveSettingsTabObjectName(SettingsDialog* dialog, const QString& key) {
+    if (!dialog) {
+        return std::nullopt;
+    }
+
+    QTabWidget* tab_widget = dialog->GetTabWidget();
+    if (!tab_widget) {
+        return std::nullopt;
+    }
+
+    const QString normalized_key = QtGui::SettingsTabs::NormalizeTabKey(key);
+    for (int i = 0; i < tab_widget->count(); ++i) {
+        if (!tab_widget->isTabVisible(i)) {
+            continue;
+        }
+        QWidget* page = tab_widget->widget(i);
+        if (!page) {
+            continue;
+        }
+        const QString normalized_page =
+            QtGui::SettingsTabs::NormalizeTabObjectName(page->objectName());
+        if (normalized_page == normalized_key) {
+            return page->objectName();
+        }
+    }
+
+    return std::nullopt;
+}
+
+QStringList BuildAvailableTargets(const OpenTargetContext& context) {
+    QStringList results = GetTargetIdStrings();
+
+    if (context.gui_settings && context.compat_info && context.ipc_client) {
+        auto settings_dialog = std::make_unique<SettingsDialog>(
+            context.gui_settings, context.compat_info, context.ipc_client, nullptr,
+            context.is_game_running, context.is_game_specific, context.game_serial);
+        results.append(CollectSettingsTabTargets(settings_dialog.get()));
+        settings_dialog->close();
+    }
+
+    results.removeDuplicates();
+    results.sort();
+    return results;
+}
+
+void ReportError(const QString& message, const OpenBehavior& behavior, QWidget* parent) {
+    if (message.isEmpty()) {
+        return;
+    }
+
+    ErrorMode mode = behavior.error_mode;
+    if (mode == ErrorMode::Default) {
+        mode = parent ? ErrorMode::MessageBox : ErrorMode::StdErr;
+    }
+
+    if (mode == ErrorMode::MessageBox) {
+        QMessageBox::critical(parent, QObject::tr("Open Target"), message);
+        return;
+    }
+
+    if (mode == ErrorMode::StdErr) {
+        std::cerr << message.toStdString() << "\n";
+        return;
+    }
+}
+
+void AttachExitOnClose(QObject* target, const OpenBehavior& behavior) {
+    if (!behavior.exit_on_close || !target) {
+        return;
+    }
+
+    QObject::connect(target, &QObject::destroyed, QCoreApplication::instance(),
+                     []() { QCoreApplication::quit(); });
+}
+
+void AttachDialogExitOnClose(QDialog* dialog, const OpenBehavior& behavior) {
+    if (!behavior.exit_on_close || !dialog) {
+        return;
+    }
+
+    QObject::connect(dialog, &QDialog::finished, QCoreApplication::instance(),
+                     []() { QCoreApplication::quit(); });
+}
+
+OpenTargetResult OpenDialog(QDialog* dialog, const OpenBehavior& behavior) {
+    OpenTargetResult result;
+    result.opened_window = dialog;
+    result.success = dialog != nullptr;
+    if (!dialog) {
+        return result;
+    }
+
+    if (behavior.exit_on_close) {
+        AttachDialogExitOnClose(dialog, behavior);
+        dialog->show();
+    } else {
+        dialog->exec();
+    }
+    return result;
+}
+
+OpenTargetResult OpenWindow(QWidget* window, const OpenBehavior& behavior) {
+    OpenTargetResult result;
+    result.opened_window = window;
+    result.success = window != nullptr;
+    if (!window) {
+        return result;
+    }
+
+    AttachExitOnClose(window, behavior);
+    window->show();
+    return result;
+}
+
+void AttachParentDestroy(QWidget* parent, QWidget* child, bool attach) {
+    if (!attach || !parent || !child) {
+        return;
+    }
+
+    QObject::connect(parent, &QWidget::destroyed, child, [child]() { child->deleteLater(); });
+}
+
+std::optional<std::filesystem::path> ResolveGameTrpPath(const std::filesystem::path& game_path) {
+    auto update_path = game_path;
+    update_path += "-UPDATE";
+    if (std::filesystem::exists(update_path)) {
+        return update_path;
+    }
+
+    auto patch_path = game_path;
+    patch_path += "-patch";
+    if (std::filesystem::exists(patch_path)) {
+        return patch_path;
+    }
+
+    return game_path;
+}
+
+} // namespace
+
+OpenBehavior OpenBehaviorForUi() {
+    OpenBehavior behavior;
+    behavior.exit_on_close = false;
+    behavior.error_mode = ErrorMode::Default;
+    return behavior;
+}
+
+OpenBehavior OpenBehaviorForCli() {
+    OpenBehavior behavior;
+    behavior.exit_on_close = true;
+    behavior.error_mode = ErrorMode::StdErr;
+    return behavior;
+}
+
+std::optional<TargetId> ParseTargetId(const QString& target) {
+    const QString normalized = NormalizeTargetString(target);
+    for (const auto& entry : TargetEntries()) {
+        if (entry.name == normalized) {
+            return entry.id;
+        }
+    }
+    return std::nullopt;
+}
+
+QStringList GetTargetIdStrings() {
+    QStringList results;
+    for (const auto& entry : TargetEntries()) {
+        results.append(entry.name);
+    }
+    std::sort(results.begin(), results.end());
+    return results;
+}
+
+OpenTargetResult OpenTarget(TargetId target_id, const OpenTargetContext& context,
+                            const OpenBehavior& behavior) {
+    OpenTargetResult result;
+    result.success = false;
+
+    QWidget* parent = context.parent;
+
+    switch (target_id) {
+    case TargetId::Settings: {
+        if (!context.gui_settings || !context.compat_info || !context.ipc_client) {
+            result.error_message = QObject::tr("Settings requires GUI, compatibility, and IPC.");
+            break;
+        }
+        auto dialog = new SettingsDialog(context.gui_settings, context.compat_info,
+                                         context.ipc_client, parent, context.is_game_running,
+                                         context.is_game_specific, context.game_serial);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::VersionManager: {
+        if (!context.gui_settings) {
+            result.error_message = QObject::tr("Version Manager requires GUI settings.");
+            break;
+        }
+        auto dialog = new VersionDialog(context.gui_settings, parent);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::Controllers: {
+        if (!context.game_info || !context.ipc_client) {
+            result.error_message = QObject::tr("Controllers require game info and IPC.");
+            break;
+        }
+        auto dialog = new ControlSettings(context.game_info, context.ipc_client,
+                                          context.is_game_running, context.running_game_serial,
+                                          parent);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::KeyboardMouse: {
+        if (!context.game_info || !context.ipc_client) {
+            result.error_message = QObject::tr("Keyboard/Mouse requires game info and IPC.");
+            break;
+        }
+        auto dialog = new KBMSettings(context.game_info, context.ipc_client,
+                                      context.is_game_running, context.running_game_serial,
+                                      parent);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::Hotkeys: {
+        if (!context.ipc_client) {
+            result.error_message = QObject::tr("Hotkeys requires IPC.");
+            break;
+        }
+        auto dialog = new Hotkeys(context.ipc_client, context.is_game_running, parent);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::About: {
+        if (!context.gui_settings) {
+            result.error_message = QObject::tr("About dialog requires GUI settings.");
+            break;
+        }
+        auto dialog = new AboutDialog(context.gui_settings, parent);
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::GameInstall: {
+        auto dialog = new GameInstallDialog();
+        AttachParentDestroy(parent, dialog, context.attach_parent_destroy);
+        result = OpenDialog(dialog, behavior);
+        break;
+    }
+    case TargetId::CheatsPatchesDownload: {
+        if (!context.game_info || !context.gui_settings || !context.ipc_client) {
+            result.error_message = QObject::tr("Cheats/Patches requires game info, GUI, and IPC.");
+            break;
+        }
+        auto panel_dialog = new QDialog(parent);
+        QVBoxLayout* layout = new QVBoxLayout(panel_dialog);
+        QPushButton* download_all_cheats_button = new QPushButton(
+            QObject::tr("Download Cheats For All Installed Games"), panel_dialog);
+        QPushButton* download_all_patches_button =
+            new QPushButton(QObject::tr("Download Patches For All Games"), panel_dialog);
+
+        layout->addWidget(download_all_cheats_button);
+        layout->addWidget(download_all_patches_button);
+        panel_dialog->setLayout(layout);
+
+        QObject::connect(download_all_cheats_button, &QPushButton::clicked, panel_dialog,
+                         [panel_dialog, context]() {
+                             QEventLoop event_loop;
+                             int pending_downloads = 0;
+
+                             auto on_download_finished = [&]() {
+                                 if (--pending_downloads <= 0) {
+                                     event_loop.quit();
+                                 }
+                             };
+
+                             for (const GameInfo& game : context.game_info->m_games) {
+                                 QString empty = "";
+                                 QString game_serial = QString::fromStdString(game.serial);
+                                 QString game_version = QString::fromStdString(game.version);
+
+                                 CheatsPatches* cheats_patches =
+                                     new CheatsPatches(context.gui_settings, context.ipc_client,
+                                                       empty, empty, empty, empty, empty, nullptr);
+                                 QObject::connect(cheats_patches, &CheatsPatches::downloadFinished,
+                                                  on_download_finished);
+
+                                 pending_downloads += 2;
+
+                                 cheats_patches->downloadCheats("GoldHEN", game_serial,
+                                                                game_version, false);
+                                 cheats_patches->downloadCheats("shadPS4", game_serial,
+                                                                game_version, false);
+                             }
+                             event_loop.exec();
+
+                             QMessageBox::information(
+                                 nullptr, QObject::tr("Download Complete"),
+                                 QObject::tr("You have downloaded cheats for all the games you "
+                                             "have installed."));
+
+                             panel_dialog->accept();
+                         });
+        QObject::connect(download_all_patches_button, &QPushButton::clicked, panel_dialog,
+                         [panel_dialog, context]() {
+                             QEventLoop event_loop;
+                             int pending_downloads = 0;
+
+                             auto on_download_finished = [&]() {
+                                 if (--pending_downloads <= 0) {
+                                     event_loop.quit();
+                                 }
+                             };
+
+                             QString empty = "";
+                             CheatsPatches* cheats_patches =
+                                 new CheatsPatches(context.gui_settings, context.ipc_client, empty,
+                                                   empty, empty, empty, empty, nullptr);
+                             QObject::connect(cheats_patches, &CheatsPatches::downloadFinished,
+                                              on_download_finished);
+
+                             pending_downloads += 2;
+
+                             cheats_patches->downloadPatches("GoldHEN", false);
+                             cheats_patches->downloadPatches("shadPS4", false);
+
+                             event_loop.exec();
+                             QMessageBox::information(
+                                 nullptr, QObject::tr("Download Complete"),
+                                 QString(QObject::tr("Patches Downloaded Successfully!") + "\n" +
+                                         QObject::tr("All Patches available for all games have "
+                                                     "been downloaded.")));
+                             cheats_patches->createFilesJson("GoldHEN");
+                             cheats_patches->createFilesJson("shadPS4");
+                             panel_dialog->accept();
+                         });
+
+        AttachParentDestroy(parent, panel_dialog, context.attach_parent_destroy);
+        result = OpenDialog(panel_dialog, behavior);
+        break;
+    }
+    case TargetId::TrophyViewer: {
+        if (!context.game_info || !context.gui_settings) {
+            result.error_message =
+                QObject::tr("Trophy Viewer requires game info and GUI settings.");
+            break;
+        }
+        if (context.game_info->m_games.empty()) {
+            result.error_message = QObject::tr(
+                "No games found. Please add your games to your library first.");
+            break;
+        }
+
+        int selected_index = 0;
+        if (!context.game_serial.empty()) {
+            const auto it = std::find_if(
+                context.game_info->m_games.begin(), context.game_info->m_games.end(),
+                [&context](const GameInfo& game) { return game.serial == context.game_serial; });
+            if (it != context.game_info->m_games.end()) {
+                selected_index = static_cast<int>(std::distance(context.game_info->m_games.begin(),
+                                                                it));
+            }
+        }
+
+        const auto& selected_game = context.game_info->m_games[selected_index];
+        QString trophy_path;
+        QString game_trp_path;
+        Common::FS::PathToQString(trophy_path, selected_game.serial);
+
+        auto selected_trp_path = ResolveGameTrpPath(selected_game.path);
+        Common::FS::PathToQString(game_trp_path, *selected_trp_path);
+
+        QVector<TrophyGameInfo> all_trophy_games;
+        for (const auto& game : context.game_info->m_games) {
+            TrophyGameInfo game_info;
+            game_info.name = QString::fromStdString(game.name);
+            Common::FS::PathToQString(game_info.trophyPath, game.serial);
+            auto trp_path = ResolveGameTrpPath(game.path);
+            Common::FS::PathToQString(game_info.gameTrpPath, *trp_path);
+            all_trophy_games.append(game_info);
+        }
+
+        QString game_name = QString::fromStdString(selected_game.name);
+        auto trophy_viewer =
+            new TrophyViewer(context.gui_settings, trophy_path, game_trp_path, game_name,
+                             all_trophy_games);
+        AttachParentDestroy(parent, trophy_viewer, context.attach_parent_destroy);
+        result = OpenWindow(trophy_viewer, behavior);
+        break;
+    }
+    case TargetId::SkylanderPortal: {
+        if (!context.ipc_client) {
+            result.error_message = QObject::tr("Skylander Portal requires IPC.");
+            break;
+        }
+        if (Config::getUsbDeviceBackend() != Config::UsbBackendType::SkylandersPortal) {
+            result.error_message = QObject::tr("Skylander Portal backend is not selected.");
+            break;
+        }
+        auto dialog = skylander_dialog::get_dlg(parent, context.ipc_client);
+        result = OpenWindow(dialog, behavior);
+        break;
+    }
+    case TargetId::InfinityBase: {
+        if (!context.ipc_client) {
+            result.error_message = QObject::tr("Infinity Base requires IPC.");
+            break;
+        }
+        if (Config::getUsbDeviceBackend() != Config::UsbBackendType::InfinityBase) {
+            result.error_message = QObject::tr("Infinity Base backend is not selected.");
+            break;
+        }
+        auto dialog = infinity_dialog::get_dlg(parent, context.ipc_client);
+        result = OpenWindow(dialog, behavior);
+        break;
+    }
+    case TargetId::DimensionsToypad: {
+        if (!context.ipc_client) {
+            result.error_message = QObject::tr("Dimensions Toypad requires IPC.");
+            break;
+        }
+        if (Config::getUsbDeviceBackend() != Config::UsbBackendType::DimensionsToypad) {
+            result.error_message = QObject::tr("Dimensions Toypad backend is not selected.");
+            break;
+        }
+        auto dialog = dimensions_dialog::get_dlg(parent, context.ipc_client);
+        result = OpenWindow(dialog, behavior);
+        break;
+    }
+    }
+
+    if (!result.success && !result.error_message.isEmpty()) {
+        ReportError(result.error_message, behavior, parent);
+    }
+
+    return result;
+}
+
+OpenTargetResult OpenTarget(const QString& target, const OpenTargetContext& context,
+                            const OpenBehavior& behavior) {
+    const QString settings_key = QtGui::SettingsTabs::ExtractTabKey(target);
+    if (!settings_key.isEmpty()) {
+        OpenTargetResult result;
+        if (!context.gui_settings || !context.compat_info || !context.ipc_client) {
+            result.error_message = QObject::tr("Settings require GUI, compatibility, and IPC.");
+            ReportError(result.error_message, behavior, context.parent);
+            return result;
+        }
+
+        auto settings_dialog = std::make_unique<SettingsDialog>(
+            context.gui_settings, context.compat_info, context.ipc_client, nullptr,
+            context.is_game_running, context.is_game_specific, context.game_serial);
+        const auto object_name = ResolveSettingsTabObjectName(settings_dialog.get(), settings_key);
+        if (!object_name) {
+            const QStringList settings_targets = CollectSettingsTabTargets(settings_dialog.get());
+            result.error_message = QObject::tr("Unknown settings tab '%1'. Available: %2")
+                                       .arg(settings_key, settings_targets.join(", "));
+            ReportError(result.error_message, behavior, context.parent);
+            settings_dialog->close();
+            return result;
+        }
+
+        auto wrapper =
+            new SettingsTabDialog(settings_dialog.release(), *object_name, context.parent);
+        AttachParentDestroy(context.parent, wrapper, context.attach_parent_destroy);
+        result = OpenDialog(wrapper, behavior);
+        return result;
+    }
+
+    const auto parsed = ParseTargetId(target);
+    if (!parsed) {
+        OpenTargetResult result;
+        result.error_message = QObject::tr("Unknown target '%1'. Available: %2")
+                                   .arg(target, BuildAvailableTargets(context).join(", "));
+        ReportError(result.error_message, behavior, context.parent);
+        return result;
+    }
+
+    return OpenTarget(*parsed, context, behavior);
+}
+
+} // namespace UiOpenTargets

--- a/src/qt_gui/open_targets.h
+++ b/src/qt_gui/open_targets.h
@@ -51,7 +51,7 @@ OpenBehavior OpenBehaviorForUi();
 OpenBehavior OpenBehaviorForCli();
 
 struct OpenTargetContext {
-    std::shared_ptr<gui_settings> gui_settings;
+    std::shared_ptr<gui_settings> gui_settings_shared;
     std::shared_ptr<CompatibilityInfoClass> compat_info;
     std::shared_ptr<IpcClient> ipc_client;
     std::shared_ptr<GameInfoClass> game_info;

--- a/src/qt_gui/open_targets.h
+++ b/src/qt_gui/open_targets.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <QString>
+#include <QStringList>
+#include <QWidget>
+
+class CompatibilityInfoClass;
+class GameInfoClass;
+class IpcClient;
+class gui_settings;
+class QWidget;
+
+namespace UiOpenTargets {
+
+enum class TargetId {
+    Settings,
+    VersionManager,
+    Controllers,
+    KeyboardMouse,
+    Hotkeys,
+    About,
+    GameInstall,
+    CheatsPatchesDownload,
+    TrophyViewer,
+    SkylanderPortal,
+    InfinityBase,
+    DimensionsToypad,
+};
+
+enum class ErrorMode {
+    Default,
+    Silent,
+    MessageBox,
+    StdErr,
+};
+
+struct OpenBehavior {
+    bool exit_on_close = false;
+    ErrorMode error_mode = ErrorMode::Default;
+};
+
+OpenBehavior OpenBehaviorForUi();
+OpenBehavior OpenBehaviorForCli();
+
+struct OpenTargetContext {
+    std::shared_ptr<gui_settings> gui_settings;
+    std::shared_ptr<CompatibilityInfoClass> compat_info;
+    std::shared_ptr<IpcClient> ipc_client;
+    std::shared_ptr<GameInfoClass> game_info;
+    std::string running_game_serial;
+    bool is_game_running = false;
+    bool is_game_specific = false;
+    std::string game_serial;
+    std::optional<std::filesystem::path> game_path;
+    bool attach_parent_destroy = false;
+    QWidget* parent = nullptr;
+};
+
+struct OpenTargetResult {
+    bool success = false;
+    QString error_message;
+    QWidget* opened_window = nullptr;
+};
+
+std::optional<TargetId> ParseTargetId(const QString& target);
+QStringList GetTargetIdStrings();
+OpenTargetResult OpenTarget(TargetId target_id, const OpenTargetContext& context,
+                            const OpenBehavior& behavior);
+OpenTargetResult OpenTarget(const QString& target, const OpenTargetContext& context,
+                            const OpenBehavior& behavior);
+
+} // namespace UiOpenTargets

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -204,8 +204,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     defaultTextEdit = tr("Point your mouse at an option to display its description.");
     ui->descriptionText->setText(defaultTextEdit);
 
-    connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
-            [this]() { close_target->close(); });
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() { close_target->close(); });
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this,
             [this](QAbstractButton* button) { HandleButtonBoxClicked(button); });
@@ -1103,8 +1102,7 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
         Config::setLanguage(languageIndexes[ui->consoleLanguageComboBox->currentIndex()],
                             is_specific);
         Config::setShowSplash(ui->showSplashCheckBox->isChecked(), is_specific);
-        Config::setMainOutputDevice(ui->GenAudioComboBox->currentText().toStdString(),
-                                    is_specific);
+        Config::setMainOutputDevice(ui->GenAudioComboBox->currentText().toStdString(), is_specific);
         Config::setPadSpkOutputDevice(ui->DsAudioComboBox->currentText().toStdString(),
                                       is_specific);
         break;
@@ -1118,10 +1116,8 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
                                      ui->enableCompatibilityCheckBox->isChecked());
             m_gui_settings->SetValue(gui::gen_checkCompatibilityAtStartup,
                                      ui->checkCompatibilityOnStartupCheckBox->isChecked());
-            m_gui_settings->SetValue(gui::gl_playBackgroundMusic,
-                                     ui->playBGMCheckBox->isChecked());
-            m_gui_settings->SetValue(gui::gl_backgroundMusicVolume,
-                                     ui->BGMVolumeSlider->value());
+            m_gui_settings->SetValue(gui::gl_playBackgroundMusic, ui->playBGMCheckBox->isChecked());
+            m_gui_settings->SetValue(gui::gl_backgroundMusicVolume, ui->BGMVolumeSlider->value());
             m_gui_settings->SetValue(gui::gen_checkForUpdates, ui->updateCheckBox->isChecked());
             m_gui_settings->SetValue(gui::gen_showChangeLog, ui->changelogCheckBox->isChecked());
             m_gui_settings->SetValue(gui::gl_showBackgroundImage,
@@ -1130,18 +1126,15 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
                                      std::clamp(ui->backgroundImageOpacitySlider->value(), 0, 100));
             emit BackgroundOpacityChanged(ui->backgroundImageOpacitySlider->value());
             m_gui_settings->SetValue(
-                gui::gen_homeTab,
-                chooseHomeTabMap.value(ui->chooseHomeTabComboBox->currentText()));
+                gui::gen_homeTab, chooseHomeTabMap.value(ui->chooseHomeTabComboBox->currentText()));
         }
         break;
     }
     case SettingsTabId::Graphics: {
         Config::setIsFullscreen(
-            screenModeMap.value(ui->displayModeComboBox->currentText()) != "Windowed",
-            is_specific);
+            screenModeMap.value(ui->displayModeComboBox->currentText()) != "Windowed", is_specific);
         Config::setFullscreenMode(
-            screenModeMap.value(ui->displayModeComboBox->currentText()).toStdString(),
-            is_specific);
+            screenModeMap.value(ui->displayModeComboBox->currentText()).toStdString(), is_specific);
         Config::setPresentMode(
             presentModeMap.value(ui->presentModeComboBox->currentText()).toStdString(),
             is_specific);
@@ -1178,8 +1171,7 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
                                              is_specific);
         Config::setCursorState(ui->hideCursorComboBox->currentIndex(), is_specific);
         Config::setCursorHideTimeout(ui->hideCursorComboBox->currentIndex(), is_specific);
-        Config::setMicDevice(ui->micComboBox->currentData().toString().toStdString(),
-                             is_specific);
+        Config::setMicDevice(ui->micComboBox->currentData().toString().toStdString(), is_specific);
         Config::setUsbDeviceBackend(ui->usbComboBox->currentIndex(), is_specific);
         break;
     }
@@ -1203,8 +1195,7 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
         Config::setLogType(logTypeMap.value(ui->logTypeComboBox->currentText()).toStdString(),
                            is_specific);
         Config::setLogFilter(ui->logFilterLineEdit->text().toStdString(), is_specific);
-        Config::setSeparateLogFilesEnabled(ui->separateLogFilesCheckbox->isChecked(),
-                                           is_specific);
+        Config::setSeparateLogFilesEnabled(ui->separateLogFilesCheckbox->isChecked(), is_specific);
         break;
     }
     case SettingsTabId::Debug: {
@@ -1216,23 +1207,20 @@ void SettingsDialog::ApplySettingsForTab(SettingsTabId tab_id) {
         Config::setRdocEnabled(ui->rdocCheckBox->isChecked(), is_specific);
         Config::setVkHostMarkersEnabled(ui->hostMarkersCheckBox->isChecked(), is_specific);
         Config::setVkGuestMarkersEnabled(ui->guestMarkersCheckBox->isChecked(), is_specific);
-        Config::setVkCrashDiagnosticEnabled(ui->crashDiagnosticsCheckBox->isChecked(),
-                                            is_specific);
+        Config::setVkCrashDiagnosticEnabled(ui->crashDiagnosticsCheckBox->isChecked(), is_specific);
         Config::setCollectShaderForDebug(ui->collectShaderCheckBox->isChecked(), is_specific);
         Config::setCopyGPUCmdBuffers(ui->copyGPUBuffersCheckBox->isChecked(), is_specific);
         break;
     }
     case SettingsTabId::Experimental: {
         Config::setReadbacks(ui->readbacksCheckBox->isChecked(), is_specific);
-        Config::setReadbackLinearImages(ui->readbackLinearImagesCheckBox->isChecked(),
-                                        is_specific);
+        Config::setReadbackLinearImages(ui->readbackLinearImagesCheckBox->isChecked(), is_specific);
         Config::setDirectMemoryAccess(ui->dmaCheckBox->isChecked(), is_specific);
         Config::setDevKitConsole(ui->devkitCheckBox->isChecked(), is_specific);
         Config::setNeoMode(ui->neoCheckBox->isChecked(), is_specific);
         Config::setConnectedToNetwork(ui->networkConnectedCheckBox->isChecked(), is_specific);
         Config::setPipelineCacheEnabled(ui->shaderCaheCheckBox->isChecked(), is_specific);
-        Config::setPipelineCacheArchived(ui->shaderCacheArchiveCheckBox->isChecked(),
-                                         is_specific);
+        Config::setPipelineCacheArchived(ui->shaderCacheArchiveCheckBox->isChecked(), is_specific);
         Config::setPSNSignedIn(ui->psnSignInCheckBox->isChecked(), is_specific);
         Config::setVblankFreq(ui->vblankSpinBox->value(), is_specific);
         Config::setExtraDmemInMbytes(ui->dmemSpinBox->value(), is_specific);
@@ -1286,10 +1274,10 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
     switch (tab_id) {
     case SettingsTabId::General: {
         ui->consoleLanguageComboBox->setCurrentIndex(
-            std::distance(languageIndexes.begin(),
-                          std::find(languageIndexes.begin(), languageIndexes.end(),
-                                    toml::find_or<int>(gs_data, "Settings",
-                                                      "consoleLanguage", 6))) %
+            std::distance(
+                languageIndexes.begin(),
+                std::find(languageIndexes.begin(), languageIndexes.end(),
+                          toml::find_or<int>(gs_data, "Settings", "consoleLanguage", 6))) %
             languageIndexes.size());
 
         ui->showSplashCheckBox->setChecked(
@@ -1346,19 +1334,17 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
         break;
     }
     case SettingsTabId::Graphics: {
-        ui->graphicsAdapterBox->setCurrentIndex(
-            toml::find_or<int>(gs_data, "Vulkan", "gpuId", -1) + 1);
+        ui->graphicsAdapterBox->setCurrentIndex(toml::find_or<int>(gs_data, "Vulkan", "gpuId", -1) +
+                                                1);
         ui->widthSpinBox->setValue(toml::find_or<int>(gs_data, "GPU", "screenWidth", 1280));
         ui->heightSpinBox->setValue(toml::find_or<int>(gs_data, "GPU", "screenHeight", 720));
         ui->dumpShadersCheckBox->setChecked(
             toml::find_or<bool>(gs_data, "GPU", "dumpShaders", false));
         ui->nullGpuCheckBox->setChecked(toml::find_or<bool>(gs_data, "GPU", "nullGpu", false));
-        ui->enableHDRCheckBox->setChecked(
-            toml::find_or<bool>(gs_data, "GPU", "allowHDR", false));
+        ui->enableHDRCheckBox->setChecked(toml::find_or<bool>(gs_data, "GPU", "allowHDR", false));
         ui->FSRCheckBox->setChecked(toml::find_or<bool>(gs_data, "GPU", "fsrEnabled", true));
         ui->RCASCheckBox->setChecked(toml::find_or<bool>(gs_data, "GPU", "rcasEnabled", true));
-        ui->RCASSlider->setValue(
-            toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250));
+        ui->RCASSlider->setValue(toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250));
         ui->RCASValue->setText(QString::number(ui->RCASSlider->value() / 1000.0, 'f', 3));
 
         std::string fullScreenMode =
@@ -1375,9 +1361,8 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
         break;
     }
     case SettingsTabId::User: {
-        ui->userNameLineEdit->setText(
-            QString::fromStdString(toml::find_or<std::string>(gs_data, "General", "userName",
-                                                              "shadPS4")));
+        ui->userNameLineEdit->setText(QString::fromStdString(
+            toml::find_or<std::string>(gs_data, "General", "userName", "shadPS4")));
         ui->disableTrophycheckBox->setChecked(
             toml::find_or<bool>(gs_data, "General", "isTrophyPopupDisabled", false));
         ui->popUpDurationSpinBox->setValue(
@@ -1441,8 +1426,7 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
         break;
     }
     case SettingsTabId::Log: {
-        std::string logType =
-            toml::find_or<std::string>(gs_data, "General", "logType", "sync");
+        std::string logType = toml::find_or<std::string>(gs_data, "General", "logType", "sync");
         QString translatedText_logType = logTypeMap.key(QString::fromStdString(logType));
         if (!translatedText_logType.isEmpty()) {
             ui->logTypeComboBox->setCurrentText(translatedText_logType);
@@ -1482,15 +1466,13 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
         break;
     }
     case SettingsTabId::Experimental: {
-        ui->readbacksCheckBox->setChecked(
-            toml::find_or<bool>(gs_data, "GPU", "readbacks", false));
+        ui->readbacksCheckBox->setChecked(toml::find_or<bool>(gs_data, "GPU", "readbacks", false));
         ui->readbackLinearImagesCheckBox->setChecked(
             toml::find_or<bool>(gs_data, "GPU", "readbackLinearImages", false));
         ui->dmaCheckBox->setChecked(
             toml::find_or<bool>(gs_data, "GPU", "directMemoryAccess", false));
         ui->neoCheckBox->setChecked(toml::find_or<bool>(gs_data, "General", "isPS4Pro", false));
-        ui->devkitCheckBox->setChecked(
-            toml::find_or<bool>(gs_data, "General", "isDevKit", false));
+        ui->devkitCheckBox->setChecked(toml::find_or<bool>(gs_data, "General", "isDevKit", false));
         ui->networkConnectedCheckBox->setChecked(
             toml::find_or<bool>(gs_data, "General", "isConnectedToNetwork", false));
         ui->shaderCaheCheckBox->setChecked(
@@ -1500,8 +1482,7 @@ void SettingsDialog::LoadValuesForTab(SettingsTabId tab_id, const toml::value& d
         ui->psnSignInCheckBox->setChecked(
             toml::find_or<bool>(gs_data, "General", "isPSNSignedIn", false));
         ui->vblankSpinBox->setValue(toml::find_or<int>(gs_data, "GPU", "vblankFrequency", 60));
-        ui->dmemSpinBox->setValue(
-            toml::find_or<int>(gs_data, "General", "extraDmemInMbytes", 0));
+        ui->dmemSpinBox->setValue(toml::find_or<int>(gs_data, "General", "extraDmemInMbytes", 0));
 
         ui->shaderCaheCheckBox->isChecked() ? ui->shaderCacheArchiveCheckBox->setVisible(true)
                                             : ui->shaderCacheArchiveCheckBox->setVisible(false);
@@ -1722,8 +1703,7 @@ void SettingsDialog::SyncRunningGameGpuFromConfig(const toml::value& gs_data) {
 
     m_ipc_client->setFsr(toml::find_or<bool>(gs_data, "GPU", "fsrEnabled", true));
     m_ipc_client->setRcas(toml::find_or<bool>(gs_data, "GPU", "rcasEnabled", true));
-    m_ipc_client->setRcasAttenuation(
-        toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250));
+    m_ipc_client->setRcasAttenuation(toml::find_or<int>(gs_data, "GPU", "rcasAttenuation", 250));
 }
 
 bool SettingsDialog::LoadSyncConfigData(toml::value& data, toml::value& gs_data) const {
@@ -1737,9 +1717,9 @@ bool SettingsDialog::LoadSyncConfigData(toml::value& data, toml::value& gs_data)
 
     try {
         gs_data = is_game_specific
-            ? toml::parse(Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) /
-                          (gs_serial + ".toml"))
-            : data;
+                      ? toml::parse(Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) /
+                                    (gs_serial + ".toml"))
+                      : data;
     } catch (std::exception& ex) {
         fmt::print("Got exception trying to load config file. Exception: {}\n", ex.what());
         return false;
@@ -1747,9 +1727,6 @@ bool SettingsDialog::LoadSyncConfigData(toml::value& data, toml::value& gs_data)
 
     return true;
 }
-
-
-
 
 void SettingsDialog::pollSDLevents() {
     SDL_Event event;

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <span>
 #include <QDialog>
 #include <QGroupBox>
 #include <QPushButton>
+#include <toml.hpp>
 
 #include "common/config.h"
 #include "common/path_util.h"
@@ -19,6 +21,11 @@ namespace Ui {
 class SettingsDialog;
 }
 
+class QAbstractButton;
+class QDialogButtonBox;
+class QTabWidget;
+class QTextEdit;
+
 class SettingsDialog : public QDialog {
     Q_OBJECT
 public:
@@ -28,6 +35,13 @@ public:
                             bool is_game_running = false, bool is_game_specific = false,
                             std::string gsc_serial = "");
     ~SettingsDialog();
+
+    QTabWidget* GetTabWidget() const;
+    QDialogButtonBox* GetButtonBox() const;
+    QTextEdit* GetDescriptionText() const;
+    void SetCloseTarget(QWidget* close_target);
+    void SetSingleTabScope(const QString& tab_object_name);
+    void ClearTabScope();
 
     bool eventFilter(QObject* obj, QEvent* event) override;
     void updateNoteTextEdit(const QString& groupName);
@@ -40,14 +54,44 @@ signals:
     void BackgroundOpacityChanged(int opacity);
 
 private:
+    enum class SettingsTabId {
+        General,
+        Gui,
+        Graphics,
+        User,
+        Input,
+        Paths,
+        Log,
+        Debug,
+        Experimental,
+        Unknown,
+    };
+
+    static SettingsTabId TabIdFromObjectName(const QString& object_name);
+    static bool ShouldApplyToTab(SettingsTabId tab_id, SettingsTabId scope_tab_id);
+
+    void HandleButtonBoxClicked(QAbstractButton* button);
+    void ApplySettingsForScope();
+    void ApplySettingsForTab(SettingsTabId tab_id);
+    void LoadValuesForScope(const toml::value& data, const toml::value& gs_data,
+                            bool is_newly_created);
+    void LoadValuesForTab(SettingsTabId tab_id, const toml::value& data,
+                          const toml::value& gs_data, bool is_newly_created);
+    void SetDefaultValuesForScope();
+    void SetDefaultValuesForTab(SettingsTabId tab_id);
+    void SyncRealTimeWidgetsForScope(const toml::value& data, const toml::value& gs_data);
+    void SyncRealTimeWidgetsForTab(SettingsTabId tab_id, const toml::value& data,
+                                   const toml::value& gs_data);
+    void SyncGameFoldersFromConfig(const toml::value& data);
+    void SyncVolumeFromConfig(const toml::value& gs_data);
+    void SyncRunningGameGpuFromConfig(const toml::value& gs_data);
+    bool LoadSyncConfigData(toml::value& data, toml::value& gs_data) const;
+
     void LoadValuesFromConfig();
-    void UpdateSettings(bool game_specific = false);
-    void SyncRealTimeWidgetstoConfig();
     void InitializeEmulatorLanguages();
     void OnLanguageChanged(int index);
     void OnCursorStateChanged(s16 index);
     void closeEvent(QCloseEvent* event) override;
-    void setDefaultValues();
     void VolumeSliderChange(int value);
     void onAudioDeviceChange(bool isAdd);
     void pollSDLevents();
@@ -62,6 +106,11 @@ private:
     int initialHeight;
 
     std::string gs_serial;
+
+    std::filesystem::path config_file;
+
+    SettingsTabId scoped_tab_id = SettingsTabId::Unknown;
+    QWidget* close_target = nullptr;
 
     bool is_game_running = false;
     bool is_game_specific = false;

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -75,8 +75,8 @@ private:
     void ApplySettingsForTab(SettingsTabId tab_id);
     void LoadValuesForScope(const toml::value& data, const toml::value& gs_data,
                             bool is_newly_created);
-    void LoadValuesForTab(SettingsTabId tab_id, const toml::value& data,
-                          const toml::value& gs_data, bool is_newly_created);
+    void LoadValuesForTab(SettingsTabId tab_id, const toml::value& data, const toml::value& gs_data,
+                          bool is_newly_created);
     void SetDefaultValuesForScope();
     void SetDefaultValuesForTab(SettingsTabId tab_id);
     void SyncRealTimeWidgetsForScope(const toml::value& data, const toml::value& gs_data);

--- a/src/qt_gui/settings_tab_dialog.cpp
+++ b/src/qt_gui/settings_tab_dialog.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qt_gui/settings_tab_dialog.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QSizePolicy>
+#include <QTextEdit>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "qt_gui/settings_dialog.h"
+
+SettingsTabDialog::SettingsTabDialog(SettingsDialog* dialog, const QString& tab_object_name,
+                                     QWidget* parent)
+    : QDialog(parent), settings_dialog(dialog) {
+    if (settings_dialog) {
+        settings_dialog->setParent(this);
+        settings_dialog->SetCloseTarget(this);
+        settings_dialog->SetSingleTabScope(tab_object_name);
+        settings_dialog->hide();
+    }
+
+    QWidget* tab_page = nullptr;
+    QString tab_title;
+    QTabWidget* tab_widget = settings_dialog ? settings_dialog->GetTabWidget() : nullptr;
+    if (settings_dialog) {
+        tab_title = settings_dialog->windowTitle();
+    }
+    if (tab_widget) {
+        for (int i = 0; i < tab_widget->count(); ++i) {
+            QWidget* candidate = tab_widget->widget(i);
+            if (candidate && candidate->objectName() == tab_object_name) {
+                tab_page = candidate;
+                tab_title = tab_widget->tabText(i);
+                tab_widget->removeTab(i);
+                break;
+            }
+        }
+    }
+
+    auto layout = new QVBoxLayout(this);
+    QSize tab_hint;
+    if (tab_page) {
+        tab_page->setParent(this);
+        tab_page->setVisible(true);
+        tab_page->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        tab_page->adjustSize();
+        tab_hint = tab_page->sizeHint();
+        layout->addWidget(tab_page);
+    } else {
+        layout->addWidget(new QLabel(tr("Settings tab not found."), this));
+    }
+
+    QDialogButtonBox* button_box = settings_dialog ? settings_dialog->GetButtonBox() : nullptr;
+    QTextEdit* description_text = settings_dialog ? settings_dialog->GetDescriptionText() : nullptr;
+
+    if (settings_dialog) {
+        if (auto settings_layout = settings_dialog->layout()) {
+            settings_layout->removeWidget(button_box);
+            settings_layout->removeWidget(description_text);
+        }
+    }
+
+    QSize button_hint;
+    if (button_box) {
+        button_box->setParent(this);
+        button_box->adjustSize();
+        button_hint = button_box->sizeHint();
+        layout->addWidget(button_box);
+    }
+
+    QSize description_hint;
+    if (description_text) {
+        description_text->setParent(this);
+        description_text->adjustSize();
+        description_hint = description_text->sizeHint();
+        layout->addWidget(description_text);
+    }
+
+    layout->setStretch(0, 1);
+    layout->setStretch(1, 0);
+    layout->setStretch(2, 0);
+    setLayout(layout);
+    if (settings_dialog) {
+        QSize base_size = settings_dialog->size();
+        if (base_size.isEmpty()) {
+            base_size = settings_dialog->sizeHint();
+        }
+        if (!base_size.isEmpty()) {
+            setMinimumSize(base_size);
+            resize(base_size);
+            return;
+        }
+    }
+
+    if (!tab_hint.isEmpty()) {
+        const int min_width =
+            std::max(tab_hint.width(), std::max(button_hint.width(), description_hint.width()));
+        const int min_height =
+            tab_hint.height() + button_hint.height() + description_hint.height();
+        setMinimumSize(QSize(min_width, min_height));
+        resize(QSize(min_width, min_height));
+    }
+    if (!tab_title.isEmpty()) {
+        setWindowTitle(tab_title);
+    }
+    if (settings_dialog) {
+        setWindowIcon(settings_dialog->windowIcon());
+    }
+}
+
+SettingsTabDialog::~SettingsTabDialog() {
+    if (settings_dialog) {
+        settings_dialog->close();
+    }
+}

--- a/src/qt_gui/settings_tab_dialog.cpp
+++ b/src/qt_gui/settings_tab_dialog.cpp
@@ -6,8 +6,8 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QSizePolicy>
-#include <QTextEdit>
 #include <QTabWidget>
+#include <QTextEdit>
 #include <QVBoxLayout>
 
 #include "qt_gui/settings_dialog.h"
@@ -98,8 +98,7 @@ SettingsTabDialog::SettingsTabDialog(SettingsDialog* dialog, const QString& tab_
     if (!tab_hint.isEmpty()) {
         const int min_width =
             std::max(tab_hint.width(), std::max(button_hint.width(), description_hint.width()));
-        const int min_height =
-            tab_hint.height() + button_hint.height() + description_hint.height();
+        const int min_height = tab_hint.height() + button_hint.height() + description_hint.height();
         setMinimumSize(QSize(min_width, min_height));
         resize(QSize(min_width, min_height));
     }

--- a/src/qt_gui/settings_tab_dialog.h
+++ b/src/qt_gui/settings_tab_dialog.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QDialog>
+
+class SettingsDialog;
+
+class SettingsTabDialog final : public QDialog {
+    Q_OBJECT
+public:
+    explicit SettingsTabDialog(SettingsDialog* settings_dialog, const QString& tab_object_name,
+                               QWidget* parent = nullptr);
+    ~SettingsTabDialog() override;
+
+private:
+    SettingsDialog* settings_dialog = nullptr;
+};

--- a/src/qt_gui/settings_tab_targets.cpp
+++ b/src/qt_gui/settings_tab_targets.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qt_gui/settings_tab_targets.h"
+
+#include <QStringBuilder>
+
+namespace QtGui::SettingsTabs {
+
+namespace {
+
+QString NormalizeStringToken(const QString& input, bool strip_tab_suffix) {
+    QString trimmed = input.trimmed();
+    if (strip_tab_suffix && trimmed.endsWith("tab", Qt::CaseInsensitive) && trimmed.size() > 3) {
+        const QChar before_suffix = trimmed.at(trimmed.size() - 4);
+        if (before_suffix.isLetterOrNumber()) {
+            trimmed.chop(3);
+        }
+    }
+
+    QString output;
+    output.reserve(trimmed.size() + 4);
+
+    QChar previous;
+    for (int i = 0; i < trimmed.size(); ++i) {
+        const QChar current = trimmed.at(i);
+        if (current.isLetterOrNumber()) {
+            if (current.isUpper() && !output.isEmpty() && previous != '_' && previous != '-') {
+                output.append('_');
+            }
+            output.append(current.toLower());
+        } else if (current == '_' || current == '-' || current.isSpace()) {
+            if (!output.endsWith('_') && !output.isEmpty()) {
+                output.append('_');
+            }
+        }
+        previous = current;
+    }
+
+    while (output.endsWith('_')) {
+        output.chop(1);
+    }
+
+    return output;
+}
+
+} // namespace
+
+QString NormalizeTabObjectName(const QString& object_name) {
+    return NormalizeStringToken(object_name, true);
+}
+
+QString NormalizeTabKey(const QString& tab_key) {
+    return NormalizeStringToken(tab_key, false);
+}
+
+QString BuildTabTarget(const QString& object_name) {
+    const QString normalized = NormalizeTabObjectName(object_name);
+    if (normalized.isEmpty()) {
+        return {};
+    }
+    return QStringLiteral("settings:") % normalized;
+}
+
+QString ExtractTabKey(const QString& target) {
+    const QString trimmed = target.trimmed();
+    if (!trimmed.startsWith("settings:", Qt::CaseInsensitive)) {
+        return {};
+    }
+
+    const QString key = trimmed.mid(QStringLiteral("settings:").size());
+    return NormalizeTabKey(key);
+}
+
+bool IsSettingsTarget(const QString& target) {
+    return !ExtractTabKey(target).isEmpty();
+}
+
+} // namespace QtGui::SettingsTabs

--- a/src/qt_gui/settings_tab_targets.h
+++ b/src/qt_gui/settings_tab_targets.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QString>
+
+namespace QtGui::SettingsTabs {
+
+QString NormalizeTabObjectName(const QString& object_name);
+QString NormalizeTabKey(const QString& tab_key);
+QString BuildTabTarget(const QString& object_name);
+QString ExtractTabKey(const QString& target);
+bool IsSettingsTarget(const QString& target);
+
+} // namespace QtGui::SettingsTabs


### PR DESCRIPTION
## Summary
This PR adds a CLI entrypoint to open specific GUI windows (including individual Settings tabs) and exit when the target closes. It introduces a single routing module for all UI open targets, plus a settings-tab wrapper that can host any tab by `objectName`. Because tab IDs are derived at runtime from the Settings dialog’s tab widget, the CLI remains stable and automatically scales as new tabs are added.

## Why / Goals
- Enable external tools (like BB_Launcher or my indev Bloodborne mod manager) to open a specific GUI area via `--open <target>` and then exit cleanly. This allows utilities like those to interface with ShadPS4 settings while preventing "drift" by re-implementing the same editing logic separately (like BB_Launcher currently does).
- Allow settings tabs to be opened independently without refactoring `settings_dialog.ui` - my implementation plan specifically avoided touching this file so that it remains editable in Qt Designer.
- Ensure the open-target system stays future-proof as the Settings dialog evolves.

## Key Changes
- **New CLI parser (`cli_options.*`)** centralizes options and validation, including `--open` and game path normalization.
- **New UI router (`open_targets.*`)** maps targets to existing dialogs, validates context, and supports a CLI-friendly lifecycle.
- **New Settings tab wrapper (`settings_tab_dialog.*`)** hosts a single tab + shared footer and sizes to the full dialog.
- **New Settings tab target utilities (`settings_tab_targets.*`)** normalize `objectName`s and parse `settings:<tab>` targets.
- **Settings dialog logic refactor (`settings_dialog.*`)** adds tab scoping + per-tab apply/load/sync/default behavior so single-tab wrappers don’t touch unrelated settings.

## Notable Behavior
- `--open <target>` now opens a single UI target and exits after it closes.
- `settings:<tab>` targets are built from tab `objectName` at runtime, so new tabs automatically become available without code changes.

## Why existing files changed
- `src/main.cpp`: replaced custom CLI parsing with `Cli::ParseOptions` and added headless init + open-target execution for `--open` flows.
- `src/qt_gui/main_window.*`: added `InitMode` (Full vs Headless) so CLI openings can run required services without showing the main window.
- `src/qt_gui/gui_context_menus.h`: routed existing “open dialog” actions through the new `UiOpenTargets` module for consistency.
- `src/qt_gui/settings_dialog.*`: added tab scoping + per-tab apply/load/sync/default behavior to allow single-tab dialogs without side effects.
- `src/common/path_util.h`: added `NormalizeGamePathToEboot` to normalize `--game` paths to `eboot.bin`.
- `src/qt_gui/elf_viewer.h`: explicit Qt includes for correctness/consistency after refactors.
- `CMakeLists.txt`: adds new source files to the build.

## New source files
- src/qt_gui/cli_options.*: Centralized CLI parsing and validation (QCommandLineParser). Normalizes --game to eboot.bin and isolates --open behavior from emulator launch flags.
- src/qt_gui/open_targets.*: Single routing module for all UI open targets. Maps target IDs to dialog openers, validates required context, and supports CLI vs UI lifecycle behavior.
- src/qt_gui/settings_tab_dialog.*: Lightweight wrapper dialog that hosts a single Settings tab page plus the standard footer (Apply/Restore/Close).
- src/qt_gui/settings_tab_targets.*: Normalizes Settings tab objectNames into stable CLI IDs and parses settings:<tab> targets for dynamic tab discovery.

## How to test
- Open any dialog by name
```sh
shadPS4QtLauncher.exe --open controllers
shadPS4QtLauncher.exe --open about
```
- Open a settings tab directly:
```sh
shadPS4QtLauncher.exe --open settings:graphics
  ```
- Open a window that requires a game path (provide either eboot.bin or its folder):
```sh
shadPS4QtLauncher.exe --open trophy_viewer --game "D:\Games\MyTitle\eboot.bin"
shadPS4QtLauncher.exe --open trophy_viewer --game "D:\Games\MyTitle" (the CLI normalizes this to ...\eboot.bin)
  ```

## Conclusion
If there is any feedback here I'm happy to address it. There is potential to improve this further with dynamic registration of dialog windows, but it would require more comprehensive changes that touches more of the source. For this pass, I wanted to keep things relatively contained. Dynamic registration would make this system even more resilient; if leadership is comfortable with me making more comprehensive changes to support this feature I'll do it.

Thank you for the opportunity to collaborate! <3