### PR TITLE
Add UI option to enable/disable sys_modules

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1243,6 +1243,12 @@ void setDefaultValues(bool is_game_specific) {
         isConnectedToNetwork.set(false, is_game_specific);
         directMemoryAccessEnabled.set(false, is_game_specific);
         extraDmemInMbytes.set(0, is_game_specific);
+
+        Config::SysModulesMap modules;
+        for (const auto& name : getAllSysModules()) {
+            modules[name] = true;
+        }
+        enabledSysModules.set(modules, true);
     }
 
     // Entries with game-specific settings that are in both the game-specific and global GUI

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1161,18 +1161,11 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
     isSeparateLogFilesEnabled.setTomlValue(data, "Debug", "isSeparateLogFilesEnabled",
                                            is_game_specific);
     logEnabled.setTomlValue(data, "Debug", "logEnabled", is_game_specific);
-
-    // remover? sempre é específico, ou retornar true para todos...
-    if (is_game_specific) {
-        if (enabledSysModules.game_specific_value.has_value()) {
-            data["Debug"]["enabledSysModules"] =
-                sysModulesToToml(*enabledSysModules.game_specific_value);
-            enabledSysModules.game_specific_value = std::nullopt;
-        }
-    } else {
-        data["Debug"]["enabledSysModules"] = sysModulesToToml(enabledSysModules.base_value);
+    if (is_game_specific && enabledSysModules.game_specific_value.has_value()) {
+        data["Debug"]["enabledSysModules"] =
+            sysModulesToToml(*enabledSysModules.game_specific_value);
+        enabledSysModules.game_specific_value = std::nullopt;
     }
-
     m_language.setTomlValue(data, "Settings", "consoleLanguage", is_game_specific);
 
     if (!is_game_specific) {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -986,16 +986,18 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         current_version = toml::find_or<std::string>(debug, "ConfigVersion", current_version);
 
         if (is_game_specific) {
-            Config::SysModulesMap modules;
-            auto tbl = toml::find<toml::value>(debug, "enabledSysModules");
-            if (tbl.is_table()) {
-                for (auto& [key, val] : tbl.as_table()) {
+            auto it = debug.as_table().find("enabledSysModules");
+            if (it != debug.as_table().end() && it->second.is_table()) {
+                Config::SysModulesMap modules;
+                for (auto& [key, val] : it->second.as_table()) {
                     if (val.is_boolean()) {
                         modules[key] = val.as_boolean();
                     }
                 }
+                if (!modules.empty()) {
+                    enabledSysModules.set(modules, true);
+                }
             }
-            enabledSysModules.set(modules, is_game_specific);
         }
     }
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -92,10 +92,10 @@ public:
         base_value = t;
         return *this;
     }
-    const T get() const {
+    const T& get() const {
         switch (config_mode) {
         case ConfigMode::Default:
-            return game_specific_value.value_or(base_value);
+            return game_specific_value.has_value() ? *game_specific_value : base_value;
         case ConfigMode::Global:
             return base_value;
         case ConfigMode::Clean:
@@ -200,6 +200,12 @@ static ConfigEntry<bool> isShaderDebug(false);
 static ConfigEntry<bool> isSeparateLogFilesEnabled(false);
 static ConfigEntry<bool> showFpsCounter(false);
 static ConfigEntry<bool> logEnabled(true);
+static const std::vector<std::string> sysModules = {
+    "libSceNgs2.sprx",         "libSceUlt.sprx",       "libSceRtc.sprx",      "libSceJpegDec.sprx",
+    "libSceJpegEnc.sprx",      "libScePngEnc.sprx",    "libSceJson.sprx",     "libSceJson2.sprx",
+    "libSceLibcInternal.sprx", "libSceCesCs.sprx",     "libSceAudiodec.sprx", "libSceFont.sprx",
+    "libSceFontFt.sprx",       "libSceFreeTypeOt.sprx"};
+static ConfigEntry<Config::SysModulesMap> enabledSysModules;
 
 // GUI
 static std::vector<GameInstallDir> settings_install_dirs = {};
@@ -222,6 +228,14 @@ static string config_version = Common::g_scm_rev;
 // These entries aren't stored in the config
 static bool overrideControllerColor = false;
 static int controllerCustomColorRGB[3] = {0, 0, 255};
+
+static toml::value sysModulesToToml(const Config::SysModulesMap& modules) {
+    toml::value tbl = toml::table();
+    for (auto& [name, enabled] : modules) {
+        tbl[name] = enabled;
+    }
+    return tbl;
+}
 
 std::filesystem::path getSysModulesPath() {
     if (sys_modules_path.empty()) {
@@ -840,6 +854,18 @@ void setUsbDeviceBackend(int value, bool is_game_specific) {
     usbDeviceBackend.set(value, is_game_specific);
 }
 
+const std::vector<std::string>& getAllSysModules() {
+    return sysModules;
+}
+
+const Config::SysModulesMap& getEnabledSysModules() {
+    return enabledSysModules.get();
+}
+
+void setEnabledSysModules(const Config::SysModulesMap& modules, bool is_game_specific) {
+    enabledSysModules.set(modules, is_game_specific);
+}
+
 void load(const std::filesystem::path& path, bool is_game_specific) {
     // If the configuration file does not exist, create it and return, unless it is game specific
     std::error_code error;
@@ -958,6 +984,19 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         showFpsCounter.setFromToml(debug, "showFpsCounter", is_game_specific);
         logEnabled.setFromToml(debug, "logEnabled", is_game_specific);
         current_version = toml::find_or<std::string>(debug, "ConfigVersion", current_version);
+
+        if (is_game_specific) {
+            Config::SysModulesMap modules;
+            auto tbl = toml::find<toml::value>(debug, "enabledSysModules");
+            if (tbl.is_table()) {
+                for (auto& [key, val] : tbl.as_table()) {
+                    if (val.is_boolean()) {
+                        modules[key] = val.as_boolean();
+                    }
+                }
+            }
+            enabledSysModules.set(modules, is_game_specific);
+        }
     }
 
     if (data.contains("GUI")) {
@@ -1122,6 +1161,17 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
     isSeparateLogFilesEnabled.setTomlValue(data, "Debug", "isSeparateLogFilesEnabled",
                                            is_game_specific);
     logEnabled.setTomlValue(data, "Debug", "logEnabled", is_game_specific);
+
+    // remover? sempre é específico, ou retornar true para todos...
+    if (is_game_specific) {
+        if (enabledSysModules.game_specific_value.has_value()) {
+            data["Debug"]["enabledSysModules"] =
+                sysModulesToToml(*enabledSysModules.game_specific_value);
+            enabledSysModules.game_specific_value = std::nullopt;
+        }
+    } else {
+        data["Debug"]["enabledSysModules"] = sysModulesToToml(enabledSysModules.base_value);
+    }
 
     m_language.setTomlValue(data, "Settings", "consoleLanguage", is_game_specific);
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -4,10 +4,13 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
+#include <unordered_map>
 #include <vector>
 #include "types.h"
 
 namespace Config {
+using SysModulesMap = std::unordered_map<std::string, bool>;
 
 enum class ConfigMode {
     Default,
@@ -151,12 +154,15 @@ void setRcasAttenuation(int value, bool is_game_specific = false);
 bool getIsConnectedToNetwork();
 void setConnectedToNetwork(bool enable, bool is_game_specific = false);
 void setUserName(const std::string& name, bool is_game_specific = false);
+void setEnabledSysModules(const SysModulesMap& modules, bool is_game_specific);
 std::filesystem::path getSysModulesPath();
 void setSysModulesPath(const std::filesystem::path& path);
 
 enum UsbBackendType : int { Real, SkylandersPortal, InfinityBase, DimensionsToypad };
 int getUsbDeviceBackend();
 void setUsbDeviceBackend(int value, bool is_game_specific = false);
+const std::vector<std::string>& getAllSysModules();
+const SysModulesMap& getEnabledSysModules();
 
 // TODO
 std::filesystem::path GetSaveDataPath();

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1439,7 +1439,7 @@ void SettingsDialog::PopulateModules() {
         }
 
         // If the module file does not exist in the folder (Name in red and warning)
-        checkBox->setChecked(enabled); // && exists
+        checkBox->setChecked(enabled);
         if (!exists) {
             QPalette palette = checkBox->palette();
             palette.setColor(QPalette::WindowText, Qt::red);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -548,6 +548,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->shaderCacheArchiveCheckBox->installEventFilter(this);
         ui->psnSignInCheckBox->installEventFilter(this);
         ui->dmemGroupBox->installEventFilter(this);
+        ui->groupBox_SystemModules->installEventFilter(this);
     }
 
     SDL_InitSubSystem(SDL_INIT_EVENTS);
@@ -1043,8 +1044,9 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Enable Readback Linear Images:\\nEnables async downloading of GPU modified linear images.\\nMight fix issues in some games.");
     } else if (elementName == "dmemGroupBox") {
         text = tr("Additional DMem Allocation:\\nForces allocation of the specified amount of additional DMem. Crashes or causes issues in some games.");
+    } else if (elementName == "groupBox_SystemModules") {
+        text = tr("System Modules:\\nInternal parts of the PS4 system that make the console/emulator work.\\nEach module has a specific function. When enabled, the emulator loads the LLE file.\\nIf disabled or if the file is missing, an HLE version is used when available. If no HLE version exists, the module is not loaded.");
     }
-
     // clang-format on
     ui->descriptionText->setText(text.replace("\\n", "\n"));
 }
@@ -1424,6 +1426,7 @@ void SettingsDialog::PopulateModules() {
 
     const bool useDefaultAllEnabled = enabledModules.empty();
 
+    ui->label_moduleMissingNotice->setStyleSheet("QLabel { color: red; }");
     ui->label_moduleMissingNotice->setVisible(false);
 
     for (const auto& module : AllSysModules) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -399,8 +399,8 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
             QString initial_path;
             Common::FS::PathToQString(initial_path, sysmodules_path);
 
-            QString sysmodules_path_string =
-                QFileDialog::getExistingDirectory(this, tr("Select the DLC folder"), initial_path);
+            QString sysmodules_path_string = QFileDialog::getExistingDirectory(
+                this, tr("Select the System Modules folder"), initial_path);
 
             auto file_path = Common::FS::PathFromQString(sysmodules_path_string);
             if (!file_path.empty()) {
@@ -591,16 +591,16 @@ void SettingsDialog::LoadValuesFromConfig() {
         is_newly_created = true;
     }
 
+    toml::value data;
     try {
         std::ifstream ifs;
         ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-        const toml::value data = toml::parse(config_file);
+        data = toml::parse(config_file);
     } catch (std::exception& ex) {
         fmt::print("Got exception trying to load config file. Exception: {}\n", ex.what());
         return;
     }
 
-    const toml::value data = toml::parse(config_file);
     const QVector<int> languageIndexes = {21, 23, 14, 6, 18, 1, 12, 22, 2, 4,  25, 24, 29, 5,  0, 9,
                                           15, 16, 17, 7, 26, 8, 11, 20, 3, 13, 27, 10, 19, 30, 28};
 
@@ -797,6 +797,20 @@ void SettingsDialog::LoadValuesFromConfig() {
     if (indexTab == -1 || !ui->tabWidgetSettings->isTabVisible(indexTab) || is_newly_created)
         indexTab = 0;
     ui->tabWidgetSettings->setCurrentIndex(indexTab);
+
+    if (data.contains("Debug")) {
+        const toml::value& debug = data.at("Debug");
+        Config::SysModulesMap modules;
+        if (debug.contains("enabledSysModules") && debug.at("enabledSysModules").is_table()) {
+            for (const auto& [key, val] : debug.at("enabledSysModules").as_table()) {
+                if (val.is_boolean()) {
+                    modules[key] = val.as_boolean();
+                }
+            }
+        }
+        Config::setEnabledSysModules(modules, is_game_specific);
+        PopulateModules();
+    }
 }
 
 void SettingsDialog::InitializeEmulatorLanguages() {
@@ -1051,6 +1065,27 @@ bool SettingsDialog::eventFilter(QObject* obj, QEvent* event) {
     return QDialog::eventFilter(obj, event);
 }
 
+Config::SysModulesMap SettingsDialog::getEnabledSysModulesFromUI() const {
+    Config::SysModulesMap modules;
+
+    auto layout = ui->verticalLayout_SystemModules;
+    for (int i = 0; i < layout->count(); ++i) {
+        auto item = layout->itemAt(i);
+        if (!item)
+            continue;
+
+        auto widget = item->widget();
+        if (!widget)
+            continue;
+
+        if (auto* cb = qobject_cast<QCheckBox*>(widget)) {
+            modules[cb->text().toStdString()] = cb->isChecked();
+        }
+    }
+
+    return modules;
+}
+
 void SettingsDialog::UpdateSettings(bool is_specific) {
     // Entries with game-specific settings, needs the game-specific arg
     Config::setReadbacks(ui->readbacksCheckBox->isChecked(), is_specific);
@@ -1120,6 +1155,7 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
     Config::setVkCrashDiagnosticEnabled(ui->crashDiagnosticsCheckBox->isChecked(), is_specific);
     Config::setCollectShaderForDebug(ui->collectShaderCheckBox->isChecked(), is_specific);
     Config::setCopyGPUCmdBuffers(ui->copyGPUBuffersCheckBox->isChecked(), is_specific);
+    Config::setEnabledSysModules(getEnabledSysModulesFromUI(), is_specific);
 
     // Entries with no game-specific settings
     if (!is_specific) {
@@ -1369,4 +1405,48 @@ void SettingsDialog::getPhysicalDevices() {
     }
 
     vkDestroyInstance(instance, nullptr);
+}
+
+void SettingsDialog::PopulateModules() {
+    while (QLayoutItem* item = ui->verticalLayout_SystemModules->takeAt(0)) {
+        if (QWidget* widget = item->widget()) {
+            widget->deleteLater();
+        }
+        delete item;
+    }
+    const auto& AllSysModules = Config::getAllSysModules();
+    const auto& enabledModules = Config::getEnabledSysModules();
+    const auto sysmodules_path = Config::getSysModulesPath();
+
+    QString sysmodules_path_string;
+    Common::FS::PathToQString(sysmodules_path_string, sysmodules_path);
+    QDir dir(sysmodules_path_string);
+
+    const bool useDefaultAllEnabled = enabledModules.empty();
+
+    ui->label_moduleMissingNotice->setVisible(false);
+
+    for (const auto& module : AllSysModules) {
+        const QString moduleName = QString::fromStdString(module);
+        const QString fullPath = dir.filePath(moduleName);
+        auto* checkBox = new QCheckBox(moduleName, this);
+        const bool exists = QFileInfo::exists(fullPath);
+        bool enabled = true;
+
+        if (!useDefaultAllEnabled) {
+            auto it = enabledModules.find(module);
+            enabled = (it != enabledModules.end()) ? it->second : true;
+        }
+
+        // If the module file does not exist in the folder (Name in red and warning)
+        checkBox->setChecked(enabled); // && exists
+        if (!exists) {
+            QPalette palette = checkBox->palette();
+            palette.setColor(QPalette::WindowText, Qt::red);
+            palette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::red);
+            checkBox->setPalette(palette);
+            ui->label_moduleMissingNotice->setVisible(true);
+        }
+        ui->verticalLayout_SystemModules->addWidget(checkBox);
+    }
 }

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -30,6 +30,7 @@ public:
     ~SettingsDialog();
 
     bool eventFilter(QObject* obj, QEvent* event) override;
+    Config::SysModulesMap getEnabledSysModulesFromUI() const;
     void updateNoteTextEdit(const QString& groupName);
 
     int exec() override;
@@ -52,6 +53,7 @@ private:
     void onAudioDeviceChange(bool isAdd);
     void pollSDLevents();
     void getPhysicalDevices();
+    void PopulateModules();
 
     std::unique_ptr<Ui::SettingsDialog> ui;
 

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -2644,7 +2644,7 @@
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_10">
               <item>
-               <widget class="QGroupBox" name="groupBox_2">
+               <widget class="QGroupBox" name="groupBox_SystemModules">
                 <property name="title">
                  <string>System Modules</string>
                 </property>
@@ -2671,29 +2671,29 @@
                    </property>
                   </layout>
                  </item>
+                 <item>
+                  <widget class="QLabel" name="label_moduleMissingNotice">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <pointsize>11</pointsize>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>*Red modules are missing from the specified folder.</string>
+                   </property>
+                  </widget>
+                 </item>
                 </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_moduleMissingNotice">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>11</pointsize>
-                  <bold>false</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>*Modules marked in red were not found in the specified folder.</string>
-                </property>
                </widget>
               </item>
               <item>
@@ -2723,7 +2723,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+                 <string>WARNING: These features are experimental and should not be changed unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
                 </property>
                 <property name="scaledContents">
                  <bool>false</bool>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>970</width>
-    <height>769</height>
+    <height>775</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>8</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -77,7 +77,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -353,7 +353,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -953,7 +953,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1317,7 +1317,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1584,7 +1584,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0,0">
@@ -1892,7 +1892,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>505</height>
+         <height>511</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -2412,7 +2412,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>459</height>
+         <height>499</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2516,142 +2516,233 @@
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QGroupBox" name="dmemGroupBox">
+                 <property name="title">
+                  <string>Additional DMem Allocation</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_4">
+                  <property name="spacing">
+                   <number>5</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QSpinBox" name="dmemSpinBox">
+                    <property name="frame">
+                     <bool>true</bool>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                    </property>
+                    <property name="specialValueText">
+                     <string/>
+                    </property>
+                    <property name="accelerated">
+                     <bool>true</bool>
+                    </property>
+                    <property name="correctionMode">
+                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                    </property>
+                    <property name="keyboardTracking">
+                     <bool>false</bool>
+                    </property>
+                    <property name="suffix">
+                     <string notr="true">MB</string>
+                    </property>
+                    <property name="minimum">
+                     <number>0</number>
+                    </property>
+                    <property name="maximum">
+                     <number>100000</number>
+                    </property>
+                    <property name="value">
+                     <number>0</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="heightDivider">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Vblank Frequency</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="vblankLayout">
+                  <property name="spacing">
+                   <number>5</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QSpinBox" name="vblankSpinBox">
+                    <property name="frame">
+                     <bool>true</bool>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                    </property>
+                    <property name="specialValueText">
+                     <string/>
+                    </property>
+                    <property name="accelerated">
+                     <bool>true</bool>
+                    </property>
+                    <property name="correctionMode">
+                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                    </property>
+                    <property name="keyboardTracking">
+                     <bool>false</bool>
+                    </property>
+                    <property name="suffix">
+                     <string notr="true">Hz</string>
+                    </property>
+                    <property name="minimum">
+                     <number>60</number>
+                    </property>
+                    <property name="maximum">
+                     <number>9999</number>
+                    </property>
+                    <property name="value">
+                     <number>60</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_10">
               <item>
-               <widget class="QGroupBox" name="dmemGroupBox">
+               <widget class="QGroupBox" name="groupBox_2">
                 <property name="title">
-                 <string>Additional DMem Allocation</string>
+                 <string>System Modules</string>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_4">
+                <layout class="QVBoxLayout" name="verticalLayout_15">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>9</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
                  <item>
-                  <widget class="QSpinBox" name="dmemSpinBox">
-                   <property name="frame">
-                    <bool>true</bool>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                   </property>
-                   <property name="specialValueText">
-                    <string/>
-                   </property>
-                   <property name="accelerated">
-                    <bool>true</bool>
-                   </property>
-                   <property name="correctionMode">
-                    <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                   </property>
-                   <property name="keyboardTracking">
-                    <bool>false</bool>
-                   </property>
-                   <property name="suffix">
-                    <string notr="true">MB</string>
-                   </property>
-                   <property name="minimum">
+                  <layout class="QVBoxLayout" name="verticalLayout_SystemModules">
+                   <property name="spacing">
                     <number>0</number>
                    </property>
-                   <property name="maximum">
-                    <number>100000</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                  </widget>
+                  </layout>
                  </item>
                 </layout>
                </widget>
               </item>
               <item>
-               <widget class="QGroupBox" name="heightDivider">
-                <property name="title">
-                 <string>Vblank Frequency</string>
+               <widget class="QLabel" name="label_moduleMissingNotice">
+                <property name="enabled">
+                 <bool>true</bool>
                 </property>
-                <layout class="QVBoxLayout" name="vblankLayout">
-                 <item>
-                  <widget class="QSpinBox" name="vblankSpinBox">
-                   <property name="frame">
-                    <bool>true</bool>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                   </property>
-                   <property name="specialValueText">
-                    <string/>
-                   </property>
-                   <property name="accelerated">
-                    <bool>true</bool>
-                   </property>
-                   <property name="correctionMode">
-                    <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                   </property>
-                   <property name="keyboardTracking">
-                    <bool>false</bool>
-                   </property>
-                   <property name="suffix">
-                    <string notr="true">Hz</string>
-                   </property>
-                   <property name="minimum">
-                    <number>60</number>
-                   </property>
-                   <property name="maximum">
-                    <number>9999</number>
-                   </property>
-                   <property name="value">
-                    <number>60</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>11</pointsize>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>*Modules marked in red were not found in the specified folder.</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="ExperimentalLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="sizeIncrement">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="baseSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>11</pointsize>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+                </property>
+                <property name="scaledContents">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="margin">
+                 <number>0</number>
+                </property>
+                <property name="indent">
+                 <number>-1</number>
+                </property>
                </widget>
               </item>
              </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <widget class="QLabel" name="ExperimentalLabel">
-              <property name="sizeIncrement">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="baseSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>11</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
-              </property>
-              <property name="scaledContents">
-               <bool>false</bool>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="margin">
-               <number>20</number>
-              </property>
-              <property name="indent">
-               <number>-1</number>
-              </property>
-             </widget>
             </item>
            </layout>
           </item>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -76,8 +76,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>542</width>
+         <height>326</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -143,8 +143,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>408</width>
-                       <height>68</height>
+                       <width>126</width>
+                       <height>60</height>
                       </rect>
                      </property>
                      <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -333,8 +333,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>607</width>
+         <height>484</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -933,8 +933,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>659</width>
+         <height>353</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1297,8 +1297,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>497</width>
+         <height>431</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1563,8 +1563,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>535</width>
+         <height>396</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0">
@@ -1870,8 +1870,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>511</height>
+         <width>216</width>
+         <height>412</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -2014,8 +2014,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>240</height>
+         <width>324</width>
+         <height>242</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2155,8 +2155,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>418</height>
+         <width>494</width>
+         <height>421</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2386,7 +2386,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>500</height>
+         <height>476</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2512,126 +2512,136 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="dmemGroupBox">
-                 <property name="title">
-                  <string>Additional DMem Allocation</string>
+                <layout class="QHBoxLayout" name="horizontalLayout_11">
+                 <property name="spacing">
+                  <number>6</number>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_4">
-                  <property name="spacing">
-                   <number>5</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QSpinBox" name="dmemSpinBox">
-                    <property name="frame">
-                     <bool>true</bool>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                    </property>
-                    <property name="specialValueText">
-                     <string/>
-                    </property>
-                    <property name="accelerated">
-                     <bool>true</bool>
-                    </property>
-                    <property name="correctionMode">
-                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                    </property>
-                    <property name="keyboardTracking">
-                     <bool>false</bool>
-                    </property>
-                    <property name="suffix">
-                     <string notr="true">MB</string>
-                    </property>
-                    <property name="minimum">
-                     <number>0</number>
-                    </property>
-                    <property name="maximum">
-                     <number>100000</number>
-                    </property>
-                    <property name="value">
-                     <number>0</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="heightDivider">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
+                 <property name="topMargin">
+                  <number>0</number>
                  </property>
-                 <property name="title">
-                  <string>Vblank Frequency</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="vblankLayout">
-                  <property name="spacing">
-                   <number>5</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QSpinBox" name="vblankSpinBox">
-                    <property name="frame">
-                     <bool>true</bool>
+                 <item>
+                  <widget class="QGroupBox" name="heightDivider">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="title">
+                    <string>Vblank Frequency</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="vblankLayout">
+                    <property name="spacing">
+                     <number>5</number>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                    <property name="leftMargin">
+                     <number>5</number>
                     </property>
-                    <property name="specialValueText">
-                     <string/>
+                    <property name="topMargin">
+                     <number>5</number>
                     </property>
-                    <property name="accelerated">
-                     <bool>true</bool>
+                    <property name="rightMargin">
+                     <number>5</number>
                     </property>
-                    <property name="correctionMode">
-                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                    <property name="bottomMargin">
+                     <number>5</number>
                     </property>
-                    <property name="keyboardTracking">
-                     <bool>false</bool>
+                    <item>
+                     <widget class="QSpinBox" name="vblankSpinBox">
+                      <property name="frame">
+                       <bool>true</bool>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                      </property>
+                      <property name="specialValueText">
+                       <string/>
+                      </property>
+                      <property name="accelerated">
+                       <bool>true</bool>
+                      </property>
+                      <property name="correctionMode">
+                       <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                      </property>
+                      <property name="keyboardTracking">
+                       <bool>false</bool>
+                      </property>
+                      <property name="suffix">
+                       <string notr="true">Hz</string>
+                      </property>
+                      <property name="minimum">
+                       <number>60</number>
+                      </property>
+                      <property name="maximum">
+                       <number>9999</number>
+                      </property>
+                      <property name="value">
+                       <number>60</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="dmemGroupBox">
+                   <property name="title">
+                    <string>Additional DMem Allocation</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="verticalLayout_4">
+                    <property name="spacing">
+                     <number>5</number>
                     </property>
-                    <property name="suffix">
-                     <string notr="true">Hz</string>
+                    <property name="leftMargin">
+                     <number>5</number>
                     </property>
-                    <property name="minimum">
-                     <number>60</number>
+                    <property name="topMargin">
+                     <number>5</number>
                     </property>
-                    <property name="maximum">
-                     <number>9999</number>
+                    <property name="rightMargin">
+                     <number>5</number>
                     </property>
-                    <property name="value">
-                     <number>60</number>
+                    <property name="bottomMargin">
+                     <number>5</number>
                     </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
+                    <item>
+                     <widget class="QSpinBox" name="dmemSpinBox">
+                      <property name="frame">
+                       <bool>true</bool>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                      </property>
+                      <property name="specialValueText">
+                       <string/>
+                      </property>
+                      <property name="accelerated">
+                       <bool>true</bool>
+                      </property>
+                      <property name="correctionMode">
+                       <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                      </property>
+                      <property name="keyboardTracking">
+                       <bool>false</bool>
+                      </property>
+                      <property name="suffix">
+                       <string notr="true">MB</string>
+                      </property>
+                      <property name="minimum">
+                       <number>0</number>
+                      </property>
+                      <property name="maximum">
+                       <number>100000</number>
+                      </property>
+                      <property name="value">
+                       <number>0</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>


### PR DESCRIPTION
Resolves https://github.com/shadps4-emu/shadPS4/issues/614

`IF YOU DON'T QUITE UNDERSTAND WHAT THIS IS, ALWAYS LEAVE IT ENABLED (Sytem Modules)` 

These options will be available in the 'Experimental' menu, and can only be activated through the 'game specific settings'.

<img width="972" height="807" alt="image" src="https://github.com/user-attachments/assets/ac51572b-852c-4caf-bf46-093c9f151da4" />


If any file is missing, it will turn red and the following message will appear:
`*Red modules are missing from the specified folder.`

<img width="972" height="807" alt="image" src="https://github.com/user-attachments/assets/52fb475a-c7c3-4240-92f2-c59f172668c5" />
