### PR TITLE
Qt: Allow the file picker to choose executables on macOS

### DIFF
--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -93,10 +93,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
 #ifdef Q_OS_WIN
         exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
                                                tr("Executable (*.exe)"));
-#elif defined(Q_OS_LINUX)
-    exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
-                                           "Executable (*)");
-#elif defined(Q_OS_MACOS)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
                                            "Executable (*)");
 #endif

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -98,7 +98,7 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
                                            "Executable (*)");
 #elif defined(Q_OS_MACOS)
     exePath = QFileDialog::getOpenFileName(this, tr("Select executable"), QDir::rootPath(),
-                                           "Executable (*.*)");
+                                           "Executable (*)");
 #endif
 
         if (exePath.isEmpty())


### PR DESCRIPTION
When adding a custom build in the Version Manager, the file picker greys out executables on macOS 
<img width="684" height="447" alt="Screenshot 2026-02-10 at 18 34 17" src="https://github.com/user-attachments/assets/aa4227dc-81c9-4ef7-814b-82137dcef71e" />

This PR attempts to fix this issue