### PR TITLE
Dimensions: Close dim_file before IPC uses it 

### DIFF
--- a/src/qt_gui/dimensions_dialog.cpp
+++ b/src/qt_gui/dimensions_dialog.cpp
@@ -722,6 +722,7 @@ void dimensions_dialog::load_figure_path(u8 pad, u8 index, const QString& path) 
         return;
     }
 
+    dim_file.Close();
     clear_figure(pad, index);
 
     m_ipc_client->loadDimensionFigure(path.toStdString(), pad, index);


### PR DESCRIPTION
Fixes a race condition, the Skylanders dialog actually closes the file so it doesn't have this issue.