### PR TITLE
Add a CMake flag to hide the version manager for Flathub release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,9 @@ target_link_libraries(shadPS4QtLauncher PRIVATE Qt6::Widgets Qt6::Concurrent Qt6
 if (ENABLE_UPDATER)
     add_definitions(-DENABLE_UPDATER)
 endif()
+if (HIDE_VERSION_MANAGER)
+    add_definitions(-DHIDE_VERSION_MANAGER)
+endif()
 
 if (WIN32)
     target_link_libraries(shadPS4QtLauncher PRIVATE mincore)

--- a/src/qt_gui/game_install_dialog.cpp
+++ b/src/qt_gui/game_install_dialog.cpp
@@ -22,7 +22,9 @@ GameInstallDialog::GameInstallDialog() : m_gamesDirectory(nullptr) {
 
     layout->addWidget(SetupGamesDirectory());
     layout->addWidget(SetupAddonsDirectory());
+#ifndef HIDE_VERSION_MANAGER
     layout->addWidget(SetupVersionDirectory());
+#endif
     layout->addStretch();
     layout->addWidget(SetupDialogActions());
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -285,6 +285,9 @@ void MainWindow::AddUiWidgets() {
     versionLayout->addWidget(ui->versionComboBox);
     versionLayout->addWidget(ui->versionManagerButton);
     ui->versionManagerButton->setText(tr("Version Manager"));
+#ifdef HIDE_VERSION_MANAGER
+    versionContainer->setHidden(true);
+#endif
     ui->toolBar->addWidget(versionContainer);
 }
 


### PR DESCRIPTION
Relevant issue: https://github.com/flathub/net.shadps4.shadPS4/issues/62.