### PR TITLE
bring back accidentally deleted entry point

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -615,6 +615,11 @@ void MainWindow::CreateConnects() {
         userDialog->exec();
     });
 
+    connect(ui->keyManager, &QAction::triggered, this, [this]() {
+        auto keyDialog = new CryptoManagerDialog(this);
+        keyDialog->exec();
+    });
+
     connect(ui->setIconSizeTinyAct, &QAction::triggered, this, [this]() {
         if (isTableList) {
             m_game_list_frame->icon_size =


### PR DESCRIPTION
Accidentally deleted the key manager entry point when I did  https://github.com/shadps4-emu/shadps4-qtlauncher/pull/282 :)