### PR TITLE
Keyboard Remapping: auto-close gui window when saving the text editor

### DIFF
--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -154,6 +154,7 @@ void EditorDialog::onSaveClicked() {
         isHelpOpen = false;
     }
     saveFile(gameComboBox->currentText());
+    configSaved();
     reject(); // Close the dialog
 }
 

--- a/src/qt_gui/kbm_config_dialog.h
+++ b/src/qt_gui/kbm_config_dialog.h
@@ -9,33 +9,35 @@
 #include "string"
 
 class EditorDialog : public QDialog {
-Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)
-    public : explicit EditorDialog(QWidget* parent = nullptr); // Constructor
+    Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)
 
-    protected:
-        void closeEvent(QCloseEvent* event) override; // Override close event
-        void keyPressEvent(QKeyEvent* event) override;
+public:
+    explicit EditorDialog(QWidget* parent = nullptr); // Constructor
 
-    private:
-        QPlainTextEdit* editor; // Editor widget for the config file
-        QFont editorFont;       // To handle the text size
-        QString originalConfig; // Starting config string
-        std::string gameId;
+protected:
+    void closeEvent(QCloseEvent* event) override; // Override close event
+    void keyPressEvent(QKeyEvent* event) override;
 
-        QComboBox* gameComboBox; // Combo box for selecting game configurations
+private:
+    QPlainTextEdit* editor; // Editor widget for the config file
+    QFont editorFont;       // To handle the text size
+    QString originalConfig; // Starting config string
+    std::string gameId;
 
-        void loadFile(QString game); // Function to load the config file
-        void saveFile(QString game); // Function to save the config file
-        void loadInstalledGames();   // Helper to populate gameComboBox
-        bool hasUnsavedChanges();    // Checks for unsaved changes
+    QComboBox* gameComboBox; // Combo box for selecting game configurations
 
-    private slots:
-        void onSaveClicked();   // Save button slot
-        void onCancelClicked(); // Slot for handling cancel button
-        void onHelpClicked();   // Slot for handling help button
-        void onResetToDefaultClicked();
-        void onGameSelectionChanged(const QString& game); // Slot for game selection changes
+    void loadFile(QString game); // Function to load the config file
+    void saveFile(QString game); // Function to save the config file
+    void loadInstalledGames();   // Helper to populate gameComboBox
+    bool hasUnsavedChanges();    // Checks for unsaved changes
 
-    signals:
-        void configSaved();
+private slots:
+    void onSaveClicked();   // Save button slot
+    void onCancelClicked(); // Slot for handling cancel button
+    void onHelpClicked();   // Slot for handling help button
+    void onResetToDefaultClicked();
+    void onGameSelectionChanged(const QString& game); // Slot for game selection changes
+
+signals:
+    void configSaved();
 };

--- a/src/qt_gui/kbm_config_dialog.h
+++ b/src/qt_gui/kbm_config_dialog.h
@@ -9,10 +9,8 @@
 #include "string"
 
 class EditorDialog : public QDialog {
-    Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)
-
-public:
-    explicit EditorDialog(QWidget* parent = nullptr); // Constructor
+Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)
+    public : explicit EditorDialog(QWidget* parent = nullptr); // Constructor
 
 protected:
     void closeEvent(QCloseEvent* event) override; // Override close event

--- a/src/qt_gui/kbm_config_dialog.h
+++ b/src/qt_gui/kbm_config_dialog.h
@@ -12,27 +12,30 @@ class EditorDialog : public QDialog {
 Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)
     public : explicit EditorDialog(QWidget* parent = nullptr); // Constructor
 
-protected:
-    void closeEvent(QCloseEvent* event) override; // Override close event
-    void keyPressEvent(QKeyEvent* event) override;
+    protected:
+        void closeEvent(QCloseEvent* event) override; // Override close event
+        void keyPressEvent(QKeyEvent* event) override;
 
-private:
-    QPlainTextEdit* editor; // Editor widget for the config file
-    QFont editorFont;       // To handle the text size
-    QString originalConfig; // Starting config string
-    std::string gameId;
+    private:
+        QPlainTextEdit* editor; // Editor widget for the config file
+        QFont editorFont;       // To handle the text size
+        QString originalConfig; // Starting config string
+        std::string gameId;
 
-    QComboBox* gameComboBox; // Combo box for selecting game configurations
+        QComboBox* gameComboBox; // Combo box for selecting game configurations
 
-    void loadFile(QString game); // Function to load the config file
-    void saveFile(QString game); // Function to save the config file
-    void loadInstalledGames();   // Helper to populate gameComboBox
-    bool hasUnsavedChanges();    // Checks for unsaved changes
+        void loadFile(QString game); // Function to load the config file
+        void saveFile(QString game); // Function to save the config file
+        void loadInstalledGames();   // Helper to populate gameComboBox
+        bool hasUnsavedChanges();    // Checks for unsaved changes
 
-private slots:
-    void onSaveClicked();   // Save button slot
-    void onCancelClicked(); // Slot for handling cancel button
-    void onHelpClicked();   // Slot for handling help button
-    void onResetToDefaultClicked();
-    void onGameSelectionChanged(const QString& game); // Slot for game selection changes
+    private slots:
+        void onSaveClicked();   // Save button slot
+        void onCancelClicked(); // Slot for handling cancel button
+        void onHelpClicked();   // Slot for handling help button
+        void onResetToDefaultClicked();
+        void onGameSelectionChanged(const QString& game); // Slot for game selection changes
+
+    signals:
+        void configSaved();
 };

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -97,6 +97,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
     connect(ui->HelpButton, &QPushButton::clicked, this, &KBMSettings::onHelpClicked);
     connect(ui->TextEditorButton, &QPushButton::clicked, this, [this]() {
         auto kbmWindow = new EditorDialog(this);
+        connect(kbmWindow, &EditorDialog::configSaved, this, &QWidget::close);
         kbmWindow->exec();
         SetUIValuestoMappings(config_id);
     });


### PR DESCRIPTION
Closes https://github.com/shadps4-emu/shadps4-qtlauncher/issues/302

The Gui save function can only retain what's in the gui, so multiple inputs to an output are not retained when pressing save in the Gui. To fix this, the gui will just close without saving when the text editor is saved (the assumption here is that users will be using only one or the other). Not super elegant, but I think it suits our needs enough.

I can get around to actually making a Gui that actually supports multiple inputs (or maybe just 2 inputs) to an output, but not sure if I want to do that since I remember shadow wanting to rewrite the remapping gui