### PR TITLE
Trophy viewer: additional extraction fixes

### DIFF
--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -43,25 +43,78 @@ static void hexToBytes(const char* hex, unsigned char* dst) {
 }
 
 bool TRP::Extract(const std::filesystem::path& trophyPath, int index, std::string npCommId,
-                  const std::filesystem::path& outputPath) {
-
+                  const std::filesystem::path& outputPath, bool mergeBasePath) {
     std::filesystem::path trophyDir = trophyPath / "sce_sys/trophy";
-
-    if (!std::filesystem::exists(trophyDir)) {
+    if (!std::filesystem::exists(trophyDir) && !mergeBasePath) {
         LOG_WARNING(Common_Filesystem, "Trophy directory doesn't exist: {}", trophyDir.string());
         return false;
     }
 
     // Collect all .trp files in the directory
     std::vector<std::filesystem::path> trpFiles;
-    for (const auto& entry : std::filesystem::directory_iterator(trophyDir)) {
-        if (entry.is_regular_file() && entry.path().extension() == ".trp") {
-            trpFiles.push_back(entry.path());
+    if (mergeBasePath &&
+        (trophyPath.string().ends_with("-patch") || trophyPath.string().ends_with("-UPDATE"))) {
+        std::map<int, std::filesystem::path> trophyFileMap;
+        std::filesystem::path trophyBaseDir;
+
+        if (std::filesystem::exists(trophyDir)) {
+            for (const auto& entry : std::filesystem::directory_iterator(trophyDir)) {
+                if (entry.is_regular_file() && entry.path().extension() == ".trp") {
+                    // standard filename: trophyXX.trp
+                    int fileIndex = std::stoi(entry.path().filename().string().substr(6, 2));
+                    trophyFileMap.insert({fileIndex, entry.path()});
+                }
+            }
         }
+
+        if (trophyPath.string().ends_with("-patch")) {
+            trophyBaseDir = trophyPath.string().erase(trophyPath.string().length() - 6);
+        } else if (trophyPath.string().ends_with("-UPDATE")) {
+            trophyBaseDir = trophyPath.string().erase(trophyPath.string().length() - 7);
+        }
+
+        trophyBaseDir = trophyBaseDir / "sce_sys/trophy";
+        if (std::filesystem::exists(trophyBaseDir)) {
+            for (const auto& entry : std::filesystem::directory_iterator(trophyBaseDir)) {
+                if (entry.is_regular_file() && entry.path().extension() == ".trp") {
+                    // standard filename: trophyXX.trp
+                    bool skip = false;
+                    int fileIndex = std::stoi(entry.path().filename().string().substr(6, 2));
+
+                    // file already mapped
+                    for (auto const& [key, value] : trophyFileMap) {
+                        if (key == fileIndex) {
+                            skip = true;
+                            break;
+                        }
+                    }
+
+                    if (!skip) {
+                        trophyFileMap.insert({fileIndex, entry.path()});
+                    }
+                }
+            }
+        }
+
+        for (auto const& [key, value] : trophyFileMap) {
+            trpFiles.push_back(value);
+        }
+    } else {
+        for (const auto& entry : std::filesystem::directory_iterator(trophyDir)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".trp") {
+                trpFiles.push_back(entry.path());
+            }
+        }
+
+        // Sort files to ensure consistent ordering
+        std::sort(trpFiles.begin(), trpFiles.end());
     }
 
-    // Sort files to ensure consistent ordering
-    std::sort(trpFiles.begin(), trpFiles.end());
+    if (trpFiles.size() == 0) {
+        LOG_WARNING(Common_Filesystem, "No trophy file in game folder or base folder from ",
+                    trophyDir.string());
+        return false;
+    }
 
     if (index >= trpFiles.size()) {
         LOG_WARNING(Common_Filesystem, "Trophy index {} out of range (only {} .trp files found)",

--- a/src/core/file_format/trp.h
+++ b/src/core/file_format/trp.h
@@ -37,7 +37,7 @@ public:
     TRP();
     ~TRP();
     bool Extract(const std::filesystem::path& trophyPath, int index, std::string npCommId,
-                 const std::filesystem::path& outputPath);
+                 const std::filesystem::path& outputPath, bool mergeBasePath = false);
 
 private:
     bool ProcessPngEntry(Common::FS::IOFile& file, const TrpEntry& entry,

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -377,7 +377,6 @@ void TrophyViewer::reopenLeftDock() {
 }
 
 void TrophyViewer::PopulateTrophyWidget(QString title, QString user) {
-
     int index = 0;
     for (const auto& npCommId : npCommIds) {
         auto trophyFilesPath =
@@ -385,11 +384,10 @@ void TrophyViewer::PopulateTrophyWidget(QString title, QString user) {
         QString trophyDirQt;
         Common::FS::PathToQString(trophyDirQt, trophyFilesPath);
 
-        std::filesystem::path extractPath =
-            GetTrpFilesPath(Common::FS::PathFromQString(gameTrpPath_));
         QDir dir(trophyDirQt);
         if (!dir.exists()) {
-            if (!trp.Extract(extractPath, index, npCommId, trophyFilesPath)) {
+            if (!trp.Extract(Common::FS::PathFromQString(gameTrpPath_), index, npCommId,
+                             trophyFilesPath, true)) {
                 LOG_ERROR(Loader, "Couldn't extract trophies");
 
                 continue;
@@ -408,6 +406,11 @@ void TrophyViewer::PopulateTrophyWidget(QString title, QString user) {
 
         auto user_trophy_file = EmulatorSettings.GetHomeDir() / userId / "trophy" / filename;
         if (!std::filesystem::exists(user_trophy_file)) {
+
+            if (!std::filesystem::exists(user_trophy_file.parent_path())) {
+                std::filesystem::create_directories(user_trophy_file.parent_path());
+            }
+
             std::error_code discard;
             std::filesystem::copy_file(trophyFilesPath / "Xml" / "TROPCONF.XML", user_trophy_file,
                                        discard);
@@ -657,28 +660,4 @@ void TrophyViewer::SetTableItem(QTableWidget* parent, int row, int column, QStri
     }
 
     parent->setItem(row, column, item);
-}
-
-std::filesystem::path TrophyViewer::GetTrpFilesPath(std::filesystem::path gamePath) {
-    if (!gamePath.string().ends_with("-patch") && !gamePath.string().ends_with("-Update")) {
-        return gamePath;
-    }
-
-    std::string basePath = gamePath.string();
-    if (gamePath.string().ends_with("-patch")) {
-        basePath.erase(basePath.length() - 6);
-    } else if (gamePath.string().ends_with("-UDPATE")) {
-        basePath.erase(basePath.length() - 7);
-    }
-
-    if (std::filesystem::exists(gamePath / "sce_sys" / "trophy")) {
-        for (const auto& entry :
-             std::filesystem::directory_iterator(gamePath / "sce_sys" / "trophy")) {
-            if (entry.path().filename().string().ends_with(".trp")) {
-                return gamePath;
-            }
-        }
-    }
-
-    return basePath;
 }

--- a/src/qt_gui/trophy_viewer.h
+++ b/src/qt_gui/trophy_viewer.h
@@ -53,7 +53,6 @@ private:
     bool userResizedWindow_ = false;
     bool programmaticResize_ = false;
     bool initialSizeApplied_ = false;
-    std::filesystem::path GetTrpFilesPath(std::filesystem::path gamePath);
 
     QTabWidget* tabWidget = nullptr;
     QStringList headers;


### PR DESCRIPTION
I did not previously consider the scenario where trophy files can be found in a combination of base/update folders. This properly takes files from both patch/base folders as necessary while keeping the proper indices.