### PR TITLE
fix: apply game-specific config when launching via CLI (-d -g)

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1459,6 +1459,21 @@ void MainWindow::StartEmulatorExecutable(std::filesystem::path emuPath, QString 
             quick_exit(1);
         }
 
+        // Apply game-specific config overrides if available.
+        // This replicates the behavior of "Launch with game specific configs"
+        // from the GUI context menu, ensuring CLI launches also respect
+        // per-game settings stored in custom_configs/<serial>.json.
+        if (!args.contains("--config-global") && !args.contains("--config-clean")) {
+            auto gameDir = last_game_path.parent_path();
+            auto info = GameInfoClass::readGameInfo(gameDir);
+            if (!info.serial.empty()) {
+                if (EmulatorSettings.Load(info.serial)) {
+                    EmulatorSettings.Save();
+                    runningGameSerial = info.serial;
+                }
+            }
+        }
+
         QStringList game_args{"--game", QString::fromStdWString(last_game_path.wstring())};
         args.append(game_args);
     }


### PR DESCRIPTION
## Summary

When launching a game through the CLI (e.g., `shadps4-qtlauncher -d -g <path>`), the launcher only applies global settings to the generated `config.toml`, ignoring any game-specific overrides stored in `custom_configs/<serial>.json`.

This breaks integration with frontend launchers like ES-DE, Pegasus, and Steam shortcuts that rely on CLI launching.

## Changes

In `StartEmulatorExecutable()`, after resolving the game path, the fix:

1. Reads the game's serial from `param.sfo` via `GameInfoClass::readGameInfo()`
2. Calls `EmulatorSettings.Load(serial)` to load game-specific overrides
3. Calls `EmulatorSettings.Save()` to generate the merged `config.toml`

This replicates the existing behavior of the GUI's "Launch with game specific configs" context menu option.

The game-specific config merge is skipped when `--config-global` or `--config-clean` flags are explicitly passed, preserving those launch modes.

## Test plan

- [ ] Launch game via CLI with game-specific config → verify `config.toml` contains merged values
- [ ] Launch game via CLI with `--config-global` → verify only global config is applied
- [ ] Launch game via CLI without game-specific config → verify no crash, global config used
- [ ] Launch game via GUI "Launch with game specific configs" → verify unchanged behavior

Closes #315