### PR TITLE
Dont log thread name from GUI

### DIFF
--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -165,7 +165,7 @@ void Setup(std::string_view log_filename) {
     if (!already_registered) {
         already_registered = true;
         std::atexit(Shutdown);
-        std::at_quick_exit(Shutdown);
+        std::at_quick_exit(Flush);
     }
 
 #ifdef _WIN32
@@ -174,6 +174,7 @@ void Setup(std::string_view log_filename) {
     } else {
         g_console_sink = std::make_shared<spdlog::sinks::msvc_sink_mt>();
     }
+
 #else
     g_console_sink = UpdateColorLevels(std::make_shared<spdlog_stdout>());
 #endif
@@ -240,5 +241,15 @@ void Shutdown() {
 
     g_shad_file_sink.reset();
     g_console_sink.reset();
+}
+
+void Flush() {
+    if (g_shad_file_sink != nullptr) {
+        g_shad_file_sink->flush();
+    }
+
+    if (g_console_sink != nullptr) {
+        g_console_sink->flush();
+    }
 }
 } // namespace Common::Log

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -176,7 +176,7 @@ void Setup(std::string_view log_filename) {
     }
 
 #else
-    g_console_sink = UpdateColorLevels(std::make_shared<spdlog_stdout>());
+    g_console_sink = UpdateColorLevels(std::make_shared<spdlog_stdout>(spdlog::color_mode::always));
 #endif
 
     g_console_sink->set_formatter(std::make_unique<thread_name_formatter>(UNLIMITED_SIZE));

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -32,12 +32,27 @@ void Setup(std::string_view log_filename);
 
 void Shutdown();
 
-void Redirect(const std::string& name);
+void Flush();
+
+static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "Warning",
+                                               "Error", "Critical", "Off"};
+
+[[nodiscard]] static constexpr std::string_view to_string_view(spdlog::level lvl) noexcept {
+    return level_string_views.at(level_to_number(lvl));
+}
 } // namespace Common::Log
 
 // Define the fmt lib macros
-#define LOG_GENERIC(log_class, log_level, ...)                                                     \
-    SPDLOG_LOGGER_CALL(Common::Log::ALL_LOGGERS[log_class], log_level, __VA_ARGS__)
+#define LOG_GENERIC(log_class, log_level, format, ...)                                             \
+    do {                                                                                           \
+        if (auto logger = Common::Log::ALL_LOGGERS[log_class]) {                                   \
+            logger->log(log_level, "[{}] <{}> {}:{} {}: " format, log_class,                       \
+                        Common::Log::to_string_view(log_level),                                    \
+                        spdlog::source_loc::basename(__FILE__), __LINE__,                          \
+                        std::string_view(__func__) == "operator()" ? "lambda" : __func__,          \
+                        ##__VA_ARGS__);                                                            \
+        }                                                                                          \
+    } while (false)
 
 #ifdef _DEBUG
 #define LOG_TRACE(log_class, ...)                                                                  \

--- a/src/common/logging/thread_name_formatter.h
+++ b/src/common/logging/thread_name_formatter.h
@@ -12,13 +12,6 @@
 namespace Common::Log {
 static constexpr unsigned long long UNLIMITED_SIZE = 0;
 
-static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "Warning",
-                                               "Error", "Critical", "Off"};
-
-[[nodiscard]] static constexpr std::string_view to_string_view(spdlog::level lvl) noexcept {
-    return level_string_views.at(level_to_number(lvl));
-}
-
 struct thread_name_formatter : spdlog::formatter {
     ~thread_name_formatter() override = default;
 
@@ -31,27 +24,6 @@ struct thread_name_formatter : spdlog::formatter {
 
         msg.color_range_start = dest.size();
 
-        dest.push_back('[');
-        spdlog::details::fmt_helper::append_string_view(msg.logger_name, dest);
-        dest.push_back(']');
-        dest.push_back(' ');
-        dest.push_back('<');
-        spdlog::details::fmt_helper::append_string_view(Log::to_string_view(msg.log_level), dest);
-        dest.push_back('>');
-        dest.push_back(' ');
-        dest.push_back('(');
-        spdlog::details::fmt_helper::append_int(msg.thread_id, dest);
-        dest.push_back(')');
-        dest.push_back(' ');
-        spdlog::details::fmt_helper::append_string_view(msg.source.short_filename, dest);
-        dest.push_back(':');
-        spdlog::details::fmt_helper::append_int(msg.source.line, dest);
-        dest.push_back(' ');
-        spdlog::details::fmt_helper::append_string_view(
-            std::string_view(msg.source.funcname) == "operator()" ? "lambda" : msg.source.funcname,
-            dest);
-        dest.push_back(':');
-        dest.push_back(' ');
         spdlog::details::fmt_helper::append_string_view(msg.payload, dest);
         spdlog::details::fmt_helper::append_string_view(spdlog::details::os::default_eol, dest);
 


### PR DESCRIPTION
align with https://github.com/shadps4-emu/shadPS4/pull/4319 (but here in GUI and before spdlog, we didnt log thread name/id so dont do it anymore