### PR TITLE
Fix segfault caused by accessing version directory with hidden version manager

### DIFF
--- a/src/qt_gui/game_install_dialog.cpp
+++ b/src/qt_gui/game_install_dialog.cpp
@@ -148,7 +148,9 @@ void GameInstallDialog::Save() {
     // Check games directory.
     auto gamesDirectory = m_gamesDirectory->text();
     auto addonsDirectory = m_addonsDirectory->text();
+#ifndef HIDE_VERSION_MANAGER
     auto versionDirectory = m_versionDirectory->text();
+#endif
 
     if (gamesDirectory.isEmpty() || !QDir(gamesDirectory).exists() ||
         !QDir::isAbsolutePath(gamesDirectory)) {
@@ -171,6 +173,7 @@ void GameInstallDialog::Save() {
         }
     }
 
+#ifndef HIDE_VERSION_MANAGER
     if (versionDirectory.isEmpty() || !QDir::isAbsolutePath(versionDirectory)) {
         QMessageBox::critical(this, tr("Error"),
                               "The value for location to install emulator versions is not valid.");
@@ -185,11 +188,14 @@ void GameInstallDialog::Save() {
             return;
         }
     }
+#endif
 
     // Save the directories
     EmulatorSettings.AddGameInstallDir(Common::FS::PathFromQString(gamesDirectory));
     EmulatorSettings.SetAddonInstallDir(Common::FS::PathFromQString(addonsDirectory));
+#ifndef HIDE_VERSION_MANAGER
     m_gui_settings->SetValue(gui::vm_versionPath, versionDirectory);
+#endif
 
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     EmulatorSettings.Save();


### PR DESCRIPTION
When `GameInstallDialog::Save()` is called while the version manager is hidden, versionDirectory is initialized with garbage, leading to a segfault. This PR fixes the issue and guards the save functions if HIDE_VERSION_MANAGER is set.

```console
(gdb) p addonsDirectory
$2 = {d = {d = 0x55555695cc60, ptr = 0x55555695cc70 u"/storage/games/PS4/DLCs", size = 23}}
(gdb) p versionDirectory
$3 = {d = {d = 0x7ffffffd2920, ptr = 0x7ffffffd18c0 u"鹿噡啕", size = 140736817273648}}
```

Found in https://github.com/NixOS/nixpkgs/pull/474696#issuecomment-4284336912