### PR TITLE
Settings Dialog: reset to global settings upon exit

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -629,6 +629,7 @@ void SettingsDialog::closeEvent(QCloseEvent* event) {
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
     SDL_Quit();
 
+    EmulatorSettings.Load();
     QDialog::closeEvent(event);
 }
 


### PR DESCRIPTION
Closes https://github.com/shadps4-emu/shadps4-qtlauncher/issues/341