### PR TITLE
KBM controls remapping: overhaul ui to allow for alternate key bindings

### DIFF
--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QWheelEvent>
 #include <SDL3/SDL_events.h>
 
@@ -38,34 +39,92 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
         ui->ProfileComboBox->addItem(QString::fromStdString(m_game_info->m_games[i].serial));
     }
 
-    ButtonsList = {ui->CrossButton,
-                   ui->CircleButton,
-                   ui->TriangleButton,
-                   ui->SquareButton,
-                   ui->L1Button,
-                   ui->R1Button,
-                   ui->L2Button,
-                   ui->R2Button,
-                   ui->L3Button,
-                   ui->R3Button,
-                   ui->OptionsButton,
-                   ui->TouchpadLeftButton,
-                   ui->TouchpadCenterButton,
-                   ui->TouchpadRightButton,
-                   ui->DpadUpButton,
-                   ui->DpadDownButton,
-                   ui->DpadLeftButton,
-                   ui->DpadRightButton,
-                   ui->LStickUpButton,
-                   ui->LStickDownButton,
-                   ui->LStickLeftButton,
-                   ui->LStickRightButton,
-                   ui->RStickUpButton,
-                   ui->RStickDownButton,
-                   ui->RStickLeftButton,
-                   ui->RStickRightButton,
-                   ui->LHalfButton,
-                   ui->RHalfButton};
+    ButtonsList = {
+        {ui->CrossButton, "cross"},
+        {ui->CrossButton2, "cross"},
+        {ui->CrossButton3, "cross"},
+        {ui->CircleButton, "circle"},
+        {ui->CircleButton2, "circle"},
+        {ui->CircleButton3, "circle"},
+        {ui->TriangleButton, "triangle"},
+        {ui->TriangleButton2, "triangle"},
+        {ui->TriangleButton3, "triangle"},
+        {ui->SquareButton, "square"},
+        {ui->SquareButton2, "square"},
+        {ui->SquareButton3, "square"},
+        {ui->L1Button, "l1"},
+        {ui->L1Button2, "l1"},
+        {ui->L1Button3, "l1"},
+        {ui->R1Button, "r1"},
+        {ui->R1Button2, "r1"},
+        {ui->R1Button3, "r1"},
+        {ui->L2Button, "l2"},
+        {ui->L2Button2, "l2"},
+        {ui->L2Button3, "l2"},
+        {ui->R2Button, "r2"},
+        {ui->R2Button2, "r2"},
+        {ui->R2Button3, "r2"},
+        {ui->L3Button, "l3"},
+        {ui->L3Button2, "l3"},
+        {ui->L3Button3, "l3"},
+        {ui->R3Button, "r3"},
+        {ui->R3Button2, "r3"},
+        {ui->R3Button3, "r3"},
+        {ui->OptionsButton, "options"},
+        {ui->OptionsButton2, "options"},
+        {ui->OptionsButton3, "options"},
+        {ui->TouchpadLeftButton, "touchpad_left"},
+        {ui->TouchpadLeftButton2, "touchpad_left"},
+        {ui->TouchpadLeftButton3, "touchpad_left"},
+        {ui->TouchpadCenterButton, "touchpad_center"},
+        {ui->TouchpadCenterButton2, "touchpad_center"},
+        {ui->TouchpadCenterButton3, "touchpad_center"},
+        {ui->TouchpadRightButton, "touchpad_right"},
+        {ui->TouchpadRightButton2, "touchpad_right"},
+        {ui->TouchpadRightButton3, "touchpad_right"},
+        {ui->DpadUpButton, "pad_up"},
+        {ui->DpadUpButton2, "pad_up"},
+        {ui->DpadUpButton3, "pad_up"},
+        {ui->DpadDownButton, "pad_down"},
+        {ui->DpadDownButton2, "pad_down"},
+        {ui->DpadDownButton3, "pad_down"},
+        {ui->DpadLeftButton, "pad_left"},
+        {ui->DpadLeftButton2, "pad_left"},
+        {ui->DpadLeftButton3, "pad_left"},
+        {ui->DpadRightButton, "pad_right"},
+        {ui->DpadRightButton2, "pad_right"},
+        {ui->DpadRightButton3, "pad_right"},
+        {ui->LStickUpButton, "axis_left_y_minus"},
+        {ui->LStickUpButton2, "axis_left_y_minus"},
+        {ui->LStickUpButton3, "axis_left_y_minus"},
+        {ui->LStickDownButton, "axis_left_y_plus"},
+        {ui->LStickDownButton2, "axis_left_y_plus"},
+        {ui->LStickDownButton3, "axis_left_y_plus"},
+        {ui->LStickLeftButton, "axis_left_x_minus"},
+        {ui->LStickLeftButton2, "axis_left_x_minus"},
+        {ui->LStickLeftButton3, "axis_left_x_minus"},
+        {ui->LStickRightButton, "axis_left_x_plus"},
+        {ui->LStickRightButton2, "axis_left_x_plus"},
+        {ui->LStickRightButton3, "axis_left_x_plus"},
+        {ui->RStickUpButton, "axis_right_y_minus"},
+        {ui->RStickUpButton2, "axis_right_y_minus"},
+        {ui->RStickUpButton3, "axis_right_y_minus"},
+        {ui->RStickDownButton, "axis_right_y_plus"},
+        {ui->RStickDownButton2, "axis_right_y_plus"},
+        {ui->RStickDownButton3, "axis_right_y_plus"},
+        {ui->RStickLeftButton, "axis_right_x_minus"},
+        {ui->RStickLeftButton2, "axis_right_x_minus"},
+        {ui->RStickLeftButton3, "axis_right_x_minus"},
+        {ui->RStickRightButton, "axis_right_x_plus"},
+        {ui->RStickRightButton2, "axis_right_x_plus"},
+        {ui->RStickRightButton3, "axis_right_x_plus"},
+        {ui->LHalfButton, "leftjoystick_halfmode"},
+        {ui->LHalfButton2, "leftjoystick_halfmode"},
+        {ui->LHalfButton3, "leftjoystick_halfmode"},
+        {ui->RHalfButton, "rightjoystick_halfmode"},
+        {ui->RHalfButton2, "rightjoystick_halfmode"},
+        {ui->RHalfButton3, "rightjoystick_halfmode"},
+    };
 
     ButtonConnects();
     SetUIValuestoMappings("default");
@@ -153,18 +212,21 @@ tr("Do you want to overwrite existing mappings with the mappings from the Common
 }
 
 void KBMSettings::ButtonConnects() {
-    for (auto& button : ButtonsList) {
-        connect(button, &QPushButton::clicked, this, [this, &button]() { StartTimer(button); });
+    for (auto& entry : ButtonsList) {
+        connect(entry.first, &QPushButton::clicked, this,
+                [this, &entry]() { StartTimer(entry.first); });
 
-        connect(button, &QRightClickButton::rightClicked, this,
-                [this, &button]() { button->setText("unmapped"); });
+        connect(entry.first, &QRightClickButton::rightClicked, this,
+                [this, &entry]() { entry.first->setText("unmapped"); });
     }
 }
 
 void KBMSettings::DisableMappingButtons() {
-    for (const auto& i : ButtonsList) {
-        i->setEnabled(false);
+    for (auto& entry : ButtonsList) {
+        entry.first->setEnabled(false);
     }
+
+    ui->scrollArea->verticalScrollBar()->setEnabled(false);
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
@@ -172,9 +234,11 @@ void KBMSettings::DisableMappingButtons() {
 }
 
 void KBMSettings::EnableMappingButtons() {
-    for (const auto& i : ButtonsList) {
-        i->setEnabled(true);
+    for (auto& entry : ButtonsList) {
+        entry.first->setEnabled(true);
     }
+
+    ui->scrollArea->verticalScrollBar()->setEnabled(true);
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
@@ -191,63 +255,17 @@ void KBMSettings::SaveKBMConfig(bool close_on_save) {
     lines.push_back("#Keyboard bindings");
     lines.push_back("");
 
-    // Lambda to reduce repetitive code for mapping buttons to config lines
-    auto add_mapping = [&](const QString& buttonText, const std::string& output_name) {
-        input_string = buttonText.toStdString();
-        output_string = output_name;
-        lines.push_back(output_string + " = " + input_string);
+    for (const auto& entry : ButtonsList) {
+        input_string = entry.first->text().toStdString();
+        output_string = entry.second;
         if (input_string != "unmapped") {
+            lines.push_back(output_string + " = " + input_string);
             inputs.push_back(input_string);
         }
-    };
-
-    add_mapping(ui->CrossButton->text(), "cross");
-    add_mapping(ui->CircleButton->text(), "circle");
-    add_mapping(ui->TriangleButton->text(), "triangle");
-    add_mapping(ui->SquareButton->text(), "square");
+    }
 
     lines.push_back("");
-
-    add_mapping(ui->DpadUpButton->text(), "pad_up");
-    add_mapping(ui->DpadDownButton->text(), "pad_down");
-    add_mapping(ui->DpadLeftButton->text(), "pad_left");
-    add_mapping(ui->DpadRightButton->text(), "pad_right");
-
-    lines.push_back("");
-
-    add_mapping(ui->L1Button->text(), "l1");
-    add_mapping(ui->R1Button->text(), "r1");
-    add_mapping(ui->L2Button->text(), "l2");
-    add_mapping(ui->R2Button->text(), "r2");
-    add_mapping(ui->L3Button->text(), "l3");
-    add_mapping(ui->R3Button->text(), "r3");
-
-    lines.push_back("");
-
-    add_mapping(ui->TouchpadLeftButton->text(), "touchpad_left");
-    add_mapping(ui->TouchpadCenterButton->text(), "touchpad_center");
-    add_mapping(ui->TouchpadRightButton->text(), "touchpad_right");
-    add_mapping(ui->OptionsButton->text(), "options");
-
-    lines.push_back("");
-
-    add_mapping(ui->LStickUpButton->text(), "axis_left_y_minus");
-    add_mapping(ui->LStickDownButton->text(), "axis_left_y_plus");
-    add_mapping(ui->LStickLeftButton->text(), "axis_left_x_minus");
-    add_mapping(ui->LStickRightButton->text(), "axis_left_x_plus");
-
-    lines.push_back("");
-
-    add_mapping(ui->RStickUpButton->text(), "axis_right_y_minus");
-    add_mapping(ui->RStickDownButton->text(), "axis_right_y_plus");
-    add_mapping(ui->RStickLeftButton->text(), "axis_right_x_minus");
-    add_mapping(ui->RStickRightButton->text(), "axis_right_x_plus");
-
-    lines.push_back("");
-
     lines.push_back("mouse_to_joystick = " + ui->MouseJoystickBox->currentText().toStdString());
-    add_mapping(ui->LHalfButton->text(), "leftjoystick_halfmode");
-    add_mapping(ui->RHalfButton->text(), "rightjoystick_halfmode");
 
     std::string DOString = std::format("{:.2f}", (ui->DeadzoneOffsetSlider->value() / 100.f));
     std::string SMString = std::format("{:.1f}", (ui->SpeedMultiplierSlider->value() / 10.f));
@@ -287,7 +305,7 @@ void KBMSettings::SaveKBMConfig(bool close_on_save) {
         input_string = line.substr(equal_pos + 2);
 
         bool controllerInputdetected = false;
-        for (std::string input : ControllerInputs) {
+        for (const std::string& input : ControllerInputs) {
             // Needed to avoid detecting backspace while detecting back
             if (input_string.contains(input) && !input_string.contains("backspace")) {
                 controllerInputdetected = true;
@@ -315,10 +333,10 @@ void KBMSettings::SaveKBMConfig(bool close_on_save) {
 
     if (duplicateFound) {
         QStringList duplicatesList;
-        for (const QString mapping : duplicateMappings) {
-            for (const auto& button : ButtonsList) {
-                if (button->text() == mapping)
-                    duplicatesList.append(button->objectName() + " - " + mapping);
+        for (const QString& mapping : duplicateMappings) {
+            for (const auto& entry : ButtonsList) {
+                if (entry.first->text() == mapping)
+                    duplicatesList.append(entry.first->objectName() + " - " + mapping);
             }
         }
         QMessageBox::information(
@@ -399,6 +417,10 @@ void KBMSettings::SetDefault() {
 }
 
 void KBMSettings::SetUIValuestoMappings(std::string config_id) {
+    for (auto& entry : ButtonsList) {
+        entry.first->setText("unmapped");
+    }
+
     const auto config_file = Input::GetFoolproofInputConfigFile(config_id);
     std::ifstream file(config_file);
 
@@ -419,7 +441,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
         std::string input_string = line.substr(equal_pos + 2);
 
         bool controllerInputdetected = false;
-        for (std::string input : ControllerInputs) {
+        for (const std::string& input : ControllerInputs) {
             // Needed to avoid detecting backspace while detecting back
             if (input_string.contains(input) && !input_string.contains("backspace")) {
                 controllerInputdetected = true;
@@ -428,65 +450,14 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
         }
 
         if (!controllerInputdetected) {
-            if (output_string == "cross") {
-                ui->CrossButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "circle") {
-                ui->CircleButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "square") {
-                ui->SquareButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "triangle") {
-                ui->TriangleButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "l1") {
-                ui->L1Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "l2") {
-                ui->L2Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "r1") {
-                ui->R1Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "r2") {
-                ui->R2Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "l3") {
-                ui->L3Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "r3") {
-                ui->R3Button->setText(QString::fromStdString(input_string));
-            } else if (output_string == "pad_up") {
-                ui->DpadUpButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "pad_down") {
-                ui->DpadDownButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "pad_left") {
-                ui->DpadLeftButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "pad_right") {
-                ui->DpadRightButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "options") {
-                ui->OptionsButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "touchpad_left") {
-                ui->TouchpadLeftButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "touchpad_center") {
-                ui->TouchpadCenterButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "touchpad_right") {
-                ui->TouchpadRightButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_left_x_minus") {
-                ui->LStickLeftButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_left_x_plus") {
-                ui->LStickRightButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_left_y_minus") {
-                ui->LStickUpButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_left_y_plus") {
-                ui->LStickDownButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_right_x_minus") {
-                ui->RStickLeftButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_right_x_plus") {
-                ui->RStickRightButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_right_y_minus") {
-                ui->RStickUpButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "axis_right_y_plus") {
-                ui->RStickDownButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "mouse_to_joystick") {
-                ui->MouseJoystickBox->setCurrentText(QString::fromStdString(input_string));
-            } else if (output_string == "leftjoystick_halfmode") {
-                ui->LHalfButton->setText(QString::fromStdString(input_string));
-            } else if (output_string == "rightjoystick_halfmode") {
-                ui->RHalfButton->setText(QString::fromStdString(input_string));
-            } else if (output_string.contains("mouse_movement_params")) {
+            for (auto& entry : ButtonsList) {
+                if (output_string == entry.second && entry.first->text() == "unmapped") {
+                    entry.first->setText(QString::fromStdString(input_string));
+                    break;
+                }
+            }
+
+            if (output_string.contains("mouse_movement_params")) {
                 std::size_t comma_pos = line.find(',');
                 if (comma_pos != std::string::npos) {
                     const std::string old_locale = std::setlocale(LC_NUMERIC, nullptr);
@@ -518,6 +489,8 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                     // Restore locale
                     std::setlocale(LC_NUMERIC, old_locale.c_str());
                 }
+            } else if (output_string == "mouse_to_joystick") {
+                ui->MouseJoystickBox->setCurrentText(QString::fromStdString(input_string));
             }
         }
     }
@@ -565,6 +538,7 @@ void KBMSettings::StartTimer(QRightClickButton*& button) {
     MappingButton = button;
     connect(timer, &QTimer::timeout, this, [this]() { CheckMapping(MappingButton); });
     timer->start(1000);
+    button->setStyleSheet("border: 1px solid lightblue;");
 }
 
 void KBMSettings::CheckMapping(QRightClickButton*& button) {
@@ -588,15 +562,18 @@ void KBMSettings::CheckMapping(QRightClickButton*& button) {
         timer->stop();
     }
     if (MappingCompleted) {
+        button->setText(mapping);
+        button->setStyleSheet("");
+
         EnableMapping = false;
         EnableMappingButtons();
         timer->stop();
-
-        button->setText(mapping);
     }
 
     if (MappingTimer <= 0) {
         button->setText(mapping);
+        button->setStyleSheet("");
+
         EnableMapping = false;
         EnableMappingButtons();
         timer->stop();

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -38,6 +38,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
     for (int i = 0; i < m_game_info->m_games.size(); i++) {
         ui->ProfileComboBox->addItem(QString::fromStdString(m_game_info->m_games[i].serial));
     }
+    ui->CopyCommonButton->setVisible(false);
 
     ButtonsList = {
         {ui->CrossButton, "cross"},
@@ -175,21 +176,14 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get,
     });
 
     connect(ui->CopyCommonButton, &QPushButton::clicked, this, [this] {
-        if (ui->ProfileComboBox->currentText() == tr("Common Config")) {
-            QMessageBox::information(this, tr("Common Config Selected"),
-                                     // clang-format off
-tr("This button copies mappings from the Common Config to the currently selected profile, and cannot be used when the currently selected profile is the Common Config."));
-            // clang-format on
-        } else {
-            QMessageBox::StandardButton reply =
-                QMessageBox::question(this, tr("Copy values from Common Config"),
-                                      // clang-format off
+        QMessageBox::StandardButton reply =
+            QMessageBox::question(this, tr("Copy values from Common Config"),
+                                  // clang-format off
 tr("Do you want to overwrite existing mappings with the mappings from the Common Config?"),
-                                      // clang-format on
-                                      QMessageBox::Yes | QMessageBox::No);
-            if (reply == QMessageBox::Yes) {
-                SetUIValuestoMappings("default");
-            }
+                                  // clang-format on
+                                  QMessageBox::Yes | QMessageBox::No);
+        if (reply == QMessageBox::Yes) {
+            SetUIValuestoMappings("default");
         }
     });
 
@@ -500,6 +494,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
 void KBMSettings::GetGameTitle() {
     if (ui->ProfileComboBox->currentText() == tr("Common Config")) {
         ui->TitleLabel->setText(tr("Common Config"));
+        ui->CopyCommonButton->setVisible(false);
     } else {
         for (int i = 0; i < m_game_info->m_games.size(); i++) {
             if (m_game_info->m_games[i].serial ==
@@ -507,6 +502,7 @@ void KBMSettings::GetGameTitle() {
                 ui->TitleLabel->setText(QString::fromStdString(m_game_info->m_games[i].name));
             }
         }
+        ui->CopyCommonButton->setVisible(true);
     }
     config_id = (ui->ProfileComboBox->currentText() == tr("Common Config"))
                     ? "default"

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <QDialog>
+#include <QMap>
 
 #include "game_info.h"
 #include "ipc/ipc_client.h"
@@ -65,7 +66,7 @@ private:
     int MappingTimer;
     QTimer* timer;
     QRightClickButton* MappingButton;
-    QList<QRightClickButton*> ButtonsList;
+    QList<QPair<QRightClickButton*, std::string>> ButtonsList;
     std::string config_id;
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",

--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -11,12 +11,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1235</width>
-    <height>874</height>
+    <width>1000</width>
+    <height>962</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -44,1676 +44,1861 @@
     <number>6</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="focusPolicy">
-      <enum>Qt::FocusPolicy::NoFocus</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>1207</width>
-        <height>860</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_19">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QHBoxLayout" name="RemapLayout">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_left">
-           <property name="spacing">
-            <number>5</number>
-           </property>
+    <widget class="QWidget" name="Contents" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <layout class="QVBoxLayout" name="mainLayout">
+        <item>
+         <widget class="QGroupBox" name="ProfileGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="title">
+           <string>Config Selection</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_16">
            <item>
-            <widget class="QGroupBox" name="gb_dpad">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>D-Pad</string>
-             </property>
-             <layout class="QVBoxLayout" name="gb_dpad_layout">
-              <property name="spacing">
-               <number>6</number>
-              </property>
-              <property name="leftMargin">
-               <number>5</number>
-              </property>
-              <property name="topMargin">
-               <number>5</number>
-              </property>
-              <property name="rightMargin">
-               <number>5</number>
-              </property>
-              <property name="bottomMargin">
-               <number>5</number>
-              </property>
-              <item>
-               <widget class="QWidget" name="dpad_up" native="true">
-                <layout class="QHBoxLayout" name="dpad_up_layout">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_dpad_up">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>0</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Up</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_4">
-                    <item>
-                     <widget class="QRightClickButton" name="DpadUpButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="layout_dpad_left_right">
-                <item>
-                 <widget class="QGroupBox" name="gb_dpad_left">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Left</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_dpad_left_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="DpadLeftButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_dpad_right">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Right</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_dpad_right_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="DpadRightButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QWidget" name="dpad_down" native="true">
-                <layout class="QHBoxLayout" name="dpad_down_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_dpad_down">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Down</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_3">
-                    <item>
-                     <widget class="QRightClickButton" name="DpadDownButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
+            <layout class="QHBoxLayout" name="profileTitleLayout">
+             <item>
+              <widget class="QComboBox" name="ProfileComboBox">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::FocusPolicy::NoFocus</enum>
+               </property>
+               <property name="currentText">
+                <string/>
+               </property>
+               <property name="currentIndex">
+                <number>-1</number>
+               </property>
+               <property name="placeholderText">
+                <string>Common Config</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="TitleLabel">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Common Config</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
-            <spacer name="verticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Policy::Maximum</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="LeftStickDeadZoneGB">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Left Analog Halfmode</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_15">
-              <item>
-               <widget class="QRightClickButton" name="LHalfButton">
-                <property name="focusPolicy">
-                 <enum>Qt::FocusPolicy::NoFocus</enum>
-                </property>
-                <property name="text">
-                 <string>unmapped</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_2">
-                <property name="font">
-                 <font>
-                  <italic>true</italic>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>hold to move left stick at half-speed</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gb_left_stick">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Left Stick</string>
-             </property>
-             <layout class="QVBoxLayout" name="gb_left_stick_layout">
-              <property name="leftMargin">
-               <number>5</number>
-              </property>
-              <property name="topMargin">
-               <number>5</number>
-              </property>
-              <property name="rightMargin">
-               <number>5</number>
-              </property>
-              <property name="bottomMargin">
-               <number>5</number>
-              </property>
-              <item>
-               <widget class="QWidget" name="left_stick_up" native="true">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>2121</height>
-                 </size>
-                </property>
-                <layout class="QHBoxLayout" name="left_stick_up_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_left_stick_up">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Up</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_10">
-                    <item>
-                     <widget class="QRightClickButton" name="LStickUpButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="layout_left_stick_left_right">
-                <item>
-                 <widget class="QGroupBox" name="gb_left_stick_left">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Left</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="LStickLeftButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_left_stick_right">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Right</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="LStickRightButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QWidget" name="left_stick_down" native="true">
-                <layout class="QHBoxLayout" name="left_stick_down_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_left_stick_down">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>21212</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Down</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_8">
-                    <item>
-                     <widget class="QRightClickButton" name="LStickDownButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
+            <layout class="QHBoxLayout" name="profileLayout2">
+             <item>
+              <widget class="QCheckBox" name="PerGameCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::FocusPolicy::NoFocus</enum>
+               </property>
+               <property name="text">
+                <string>Use per-game configs</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="CopyCommonButton">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::FocusPolicy::NoFocus</enum>
+               </property>
+               <property name="text">
+                <string>Copy from Common Config</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0,0">
-           <property name="spacing">
-            <number>0</number>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="headerLabelsLayout">
+          <item>
+           <widget class="QLabel" name="outputLabel">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Output</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="inputLabel">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Input</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="altLabel">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Alternate Input 1</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="alt2Label">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Alternate Input 2</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::FocusPolicy::NoFocus</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>-617</y>
+             <width>968</width>
+             <height>1367</height>
+            </rect>
            </property>
-           <item>
-            <widget class="QGroupBox" name="ProfileGroupBox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="title">
-              <string>Config Selection</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignCenter</set>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_16">
+           <layout class="QVBoxLayout" name="verticalLayout_19">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout" name="scrollAreaLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+              <property name="spacing">
+               <number>0</number>
+              </property>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_6">
-                <item>
-                 <widget class="QComboBox" name="ProfileComboBox">
-                  <property name="font">
-                   <font>
-                    <pointsize>9</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::FocusPolicy::NoFocus</enum>
-                  </property>
-                  <property name="currentText">
-                   <string/>
-                  </property>
-                  <property name="currentIndex">
-                   <number>-1</number>
-                  </property>
-                  <property name="placeholderText">
-                   <string>Common Config</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="TitleLabel">
-                  <property name="font">
-                   <font>
-                    <pointsize>10</pointsize>
-                    <bold>true</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>Common Config</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
+               <widget class="QFrame" name="crossFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_21">
+                 <item>
+                  <widget class="QLabel" name="crossLabel">
+                   <property name="text">
+                    <string>Cross</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CrossButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CrossButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CrossButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <widget class="QFrame" name="circleFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_20">
+                 <item>
+                  <widget class="QLabel" name="circleLabel">
+                   <property name="text">
+                    <string>Circle</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CircleButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CircleButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="CircleButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="sqaureFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_19">
+                 <item>
+                  <widget class="QLabel" name="sqaureLabel">
+                   <property name="text">
+                    <string>Square</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="SquareButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="SquareButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="SquareButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="triangleFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_8">
+                 <item>
+                  <widget class="QLabel" name="triangleLabel">
+                   <property name="text">
+                    <string>Triangle</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TriangleButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TriangleButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TriangleButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="dpadUpFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_7">
+                 <item>
+                  <widget class="QLabel" name="dpadUpLabel">
+                   <property name="text">
+                    <string>Dpad Up</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadUpButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadUpButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadUpButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="dpadDownFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <item>
+                  <widget class="QLabel" name="dpadDownLabel">
+                   <property name="text">
+                    <string>Dpad Down</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadDownButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadDownButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadDownButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="dpadLeftFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_12">
+                 <item>
+                  <widget class="QLabel" name="dpadLeftLabel">
+                   <property name="text">
+                    <string>Dpad Left</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadLeftButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadLeftButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadLeftButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="dpadRightFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                 <item>
+                  <widget class="QLabel" name="dpadRightLabel">
+                   <property name="text">
+                    <string>Dpad Right</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadRightButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadRightButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="DpadRightButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="lstickUpFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_13">
+                 <item>
+                  <widget class="QLabel" name="lstickUpLabel">
+                   <property name="text">
+                    <string>Left Stick Up</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickUpButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickUpButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickUpButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="lstickDownFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_14">
+                 <item>
+                  <widget class="QLabel" name="lstickDownLabel">
+                   <property name="text">
+                    <string>Left Stick Down</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickDownButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickDownButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickDownButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="lstickLeftFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_16">
+                 <item>
+                  <widget class="QLabel" name="lstickLeftLabel">
+                   <property name="text">
+                    <string>Left Stick Left</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickLeftButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickLeftButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickLeftButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="lstickRightFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_15">
+                 <item>
+                  <widget class="QLabel" name="lstickRightLabel">
+                   <property name="text">
+                    <string>Left Stick Right</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickRightButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickRightButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LStickRightButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="lstickHalfmodeFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_17">
+                 <item>
+                  <widget class="QLabel" name="lstickHalfmodeLabel">
+                   <property name="text">
+                    <string>Left Analog Halfmode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LHalfButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LHalfButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="LHalfButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="rstickUpFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_22">
+                 <item>
+                  <widget class="QLabel" name="rstickUpLabel">
+                   <property name="text">
+                    <string>Right Stick Up</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickUpButton">
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickUpButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickUpButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="rstickDownFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_23">
+                 <item>
+                  <widget class="QLabel" name="rstickDownLabel">
+                   <property name="text">
+                    <string>Right Stick Down</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickDownButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickDownButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickDownButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="rstickLeftFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_25">
+                 <item>
+                  <widget class="QLabel" name="rstickLeftLabel">
+                   <property name="text">
+                    <string>Right Stick Left</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickLeftButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickLeftButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickLeftButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="rstickRightFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_24">
+                 <item>
+                  <widget class="QLabel" name="rstickRightLabel">
+                   <property name="text">
+                    <string>Right Stick Right</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickRightButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickRightButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RStickRightButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="rstickHalfmodeFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_18">
+                 <item>
+                  <widget class="QLabel" name="rstickHalfmodeLabel">
+                   <property name="text">
+                    <string>Right Analog Halfmode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RHalfButton">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RHalfButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="RHalfButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="l1Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_27">
+                 <item>
+                  <widget class="QLabel" name="l1Label">
+                   <property name="text">
+                    <string>L1</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L1Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L1Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L1Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="r1Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_28">
+                 <item>
+                  <widget class="QLabel" name="r1Label">
+                   <property name="text">
+                    <string>R1</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R1Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R1Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R1Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="l2Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_30">
+                 <item>
+                  <widget class="QLabel" name="l2Label">
+                   <property name="text">
+                    <string>L2</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L2Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L2Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L2Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="r2Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_29">
+                 <item>
+                  <widget class="QLabel" name="r2Label">
+                   <property name="text">
+                    <string>R2</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R2Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string notr="true">unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R2Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R2Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="l3Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_31">
+                 <item>
+                  <widget class="QLabel" name="l3Label">
+                   <property name="text">
+                    <string>L3</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L3Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L3Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="L3Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="r3Frame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_32">
+                 <item>
+                  <widget class="QLabel" name="r3Label">
+                   <property name="text">
+                    <string>R3</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R3Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R3Button2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="R3Button3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="optionsFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_26">
+                 <item>
+                  <widget class="QLabel" name="optionsLabel">
+                   <property name="text">
+                    <string>Options</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="OptionsButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="OptionsButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="OptionsButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="touchpadLeftFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_33">
+                 <item>
+                  <widget class="QLabel" name="touchpadLeftLabel">
+                   <property name="text">
+                    <string>Touchpad Left</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadLeftButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadLeftButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadLeftButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="touchpadCenterFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_34">
+                 <item>
+                  <widget class="QLabel" name="touchpadCenterLabel">
+                   <property name="text">
+                    <string>Touchpad Center</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadCenterButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadCenterButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadCenterButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="touchpadRightFrame">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_35">
+                 <item>
+                  <widget class="QLabel" name="touchpadRightLabel">
+                   <property name="text">
+                    <string>Touchpad Right</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadRightButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadRightButton2">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRightClickButton" name="TouchpadRightButton3">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::NoFocus</enum>
+                   </property>
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="mouseSettingsLayout">
                 <item>
-                 <widget class="QCheckBox" name="PerGameCheckBox">
+                 <widget class="QGroupBox" name="MouseParamsBox">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
                   <property name="font">
                    <font>
-                    <pointsize>9</pointsize>
                     <bold>false</bold>
                    </font>
                   </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::FocusPolicy::NoFocus</enum>
-                  </property>
-                  <property name="text">
-                   <string>Use per-game configs</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="CopyCommonButton">
-                  <property name="font">
-                   <font>
-                    <pointsize>9</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::FocusPolicy::NoFocus</enum>
-                  </property>
-                  <property name="text">
-                   <string>Copy from Common Config</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="layout_middle_top">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <item>
-              <layout class="QVBoxLayout" name="layout_l1_l2">
-               <item>
-                <widget class="QGroupBox" name="gb_l1">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">L1</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_l1_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="L1Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_l2">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">L2</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_l2_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="L2Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="layout_system_buttons" stretch="0,0">
-               <item>
-                <widget class="QGroupBox" name="groupBox_4">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="title">
-                  <string/>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_20">
-                  <item>
-                   <widget class="QPushButton" name="TextEditorButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>24</height>
-                     </size>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>Text Editor</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="HelpButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>24</height>
-                     </size>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>Help</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_options">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Options</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_start_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="OptionsButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="layout_r1_r2">
-               <item>
-                <widget class="QGroupBox" name="gb_r1">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">R1</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_r1_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="R1Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_r2">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">R2</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_r2_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="R2Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string notr="true">unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QWidget" name="widget_controller" native="true">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>200</height>
-              </size>
-             </property>
-             <layout class="QHBoxLayout" name="widget_controller_layout">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="l_controller">
-                <property name="maximumSize">
-                 <size>
-                  <width>424</width>
-                  <height>250</height>
-                 </size>
-                </property>
-                <property name="pixmap">
-                 <pixmap resource="../shadps4.qrc">:/images/KBM.png</pixmap>
-                </property>
-                <property name="scaledContents">
-                 <bool>true</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="layout_middle_bottom">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="sizeConstraint">
-              <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-             </property>
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_4">
-               <item>
-                <widget class="QGroupBox" name="gb_l3">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">L3</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_l3_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="L3Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_touchpadleft">
-                 <property name="title">
-                  <string>Touchpad Left</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_17">
-                  <item>
-                   <widget class="QRightClickButton" name="TouchpadLeftButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_21">
-               <item>
-                <widget class="QGroupBox" name="groupBox_5">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Mouse to Joystick</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_22">
-                  <item>
-                   <widget class="QComboBox" name="MouseJoystickBox">
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="label_4">
-                    <property name="font">
-                     <font>
-                      <italic>true</italic>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>*press F7 ingame to activate</string>
-                    </property>
-                    <property name="wordWrap">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_touchpadcenter">
-                 <property name="title">
-                  <string>Touchpad Center</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_11">
-                  <item>
-                   <widget class="QRightClickButton" name="TouchpadCenterButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_12">
-               <item>
-                <widget class="QGroupBox" name="gb_r3">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string notr="true">R3</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_r3_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QRightClickButton" name="R3Button">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_touchpadright">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>160</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Touchpad Right</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_9">
-                  <item>
-                   <widget class="QRightClickButton" name="TouchpadRightButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::FocusPolicy::NoFocus</enum>
-                    </property>
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_14">
-               <item>
-                <widget class="QGroupBox" name="MouseParamsBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <bold>false</bold>
-                  </font>
-                 </property>
-                 <property name="title">
-                  <string>Mouse Movement Parameters</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_18">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_9">
-                    <item>
-                     <widget class="QLabel" name="DeadzoneOffsetLabel_text">
-                      <property name="font">
-                       <font>
-                        <bold>false</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>Deadzone Offset (def 0.50):</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="DeadzoneOffsetSlider">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="maximum">
-                       <number>100</number>
-                      </property>
-                      <property name="value">
-                       <number>50</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="DeadzoneOffsetLabel">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>30</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string notr="true">0.50</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_10">
-                    <item>
-                     <widget class="QLabel" name="SpeedMultiplierLabel_text">
-                      <property name="font">
-                       <font>
-                        <bold>false</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>Speed Multiplier (def 1.0):</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="SpeedMultiplierSlider">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="minimum">
-                       <number>1</number>
-                      </property>
-                      <property name="maximum">
-                       <number>50</number>
-                      </property>
-                      <property name="pageStep">
-                       <number>5</number>
-                      </property>
-                      <property name="value">
-                       <number>10</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="SpeedMultiplierLabel">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>30</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string notr="true">1.0</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_11">
-                    <item>
-                     <widget class="QLabel" name="SpeedOffsetLabel_text">
-                      <property name="font">
-                       <font>
-                        <bold>false</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>Speed Offset (def 0.125):</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="SpeedOffsetSlider">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="maximum">
-                       <number>1000</number>
-                      </property>
-                      <property name="pageStep">
-                       <number>100</number>
-                      </property>
-                      <property name="value">
-                       <number>125</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="SpeedOffsetLabel">
-                      <property name="maximumSize">
-                       <size>
-                        <width>30</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string notr="true">0.125</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="MoreInfoLabel">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <italic>true</italic>
-                      <bold>false</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>note: click Help Button/Special Keybindings for more information</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_right">
-           <property name="spacing">
-            <number>5</number>
-           </property>
-           <item>
-            <widget class="QGroupBox" name="gb_face_buttons">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="title">
-              <string>Face Buttons</string>
-             </property>
-             <layout class="QVBoxLayout" name="gb_face_buttons_layout">
-              <property name="leftMargin">
-               <number>5</number>
-              </property>
-              <property name="topMargin">
-               <number>5</number>
-              </property>
-              <property name="rightMargin">
-               <number>5</number>
-              </property>
-              <property name="bottomMargin">
-               <number>5</number>
-              </property>
-              <item>
-               <widget class="QWidget" name="widget_triangle" native="true">
-                <layout class="QHBoxLayout" name="widget_triangle_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_triangle">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>0</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Triangle</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_3">
-                    <item>
-                     <widget class="QRightClickButton" name="TriangleButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="layout_square_circle">
-                <item>
-                 <widget class="QGroupBox" name="gb_square">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
                   <property name="title">
-                   <string>Square</string>
+                   <string>Mouse Movement Parameters</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
-                  <layout class="QVBoxLayout" name="gb_square_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_18">
                    <item>
-                    <widget class="QRightClickButton" name="SquareButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
+                    <layout class="QHBoxLayout" name="deadzoneOffsetLayout">
+                     <item>
+                      <widget class="QLabel" name="DeadzoneOffsetLabel_text">
+                       <property name="font">
+                        <font>
+                         <bold>false</bold>
+                        </font>
+                       </property>
+                       <property name="text">
+                        <string>Deadzone Offset (def 0.50):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="DeadzoneOffsetSlider">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::FocusPolicy::NoFocus</enum>
+                       </property>
+                       <property name="maximum">
+                        <number>100</number>
+                       </property>
+                       <property name="value">
+                        <number>50</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="DeadzoneOffsetLabel">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>30</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string notr="true">0.50</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="speedMultLayout">
+                     <item>
+                      <widget class="QLabel" name="SpeedMultiplierLabel_text">
+                       <property name="font">
+                        <font>
+                         <bold>false</bold>
+                        </font>
+                       </property>
+                       <property name="text">
+                        <string>Speed Multiplier (def 1.0):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="SpeedMultiplierSlider">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::FocusPolicy::NoFocus</enum>
+                       </property>
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <number>50</number>
+                       </property>
+                       <property name="pageStep">
+                        <number>5</number>
+                       </property>
+                       <property name="value">
+                        <number>10</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="SpeedMultiplierLabel">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>30</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string notr="true">1.0</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="speedOffsetLayout">
+                     <item>
+                      <widget class="QLabel" name="SpeedOffsetLabel_text">
+                       <property name="font">
+                        <font>
+                         <bold>false</bold>
+                        </font>
+                       </property>
+                       <property name="text">
+                        <string>Speed Offset (def 0.125):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="SpeedOffsetSlider">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::FocusPolicy::NoFocus</enum>
+                       </property>
+                       <property name="maximum">
+                        <number>1000</number>
+                       </property>
+                       <property name="pageStep">
+                        <number>100</number>
+                       </property>
+                       <property name="value">
+                        <number>125</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="SpeedOffsetLabel">
+                       <property name="maximumSize">
+                        <size>
+                         <width>30</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string notr="true">0.125</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="MoreInfoLabel">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="font">
+                      <font>
+                       <italic>true</italic>
+                       <bold>false</bold>
+                      </font>
                      </property>
                      <property name="text">
-                      <string>unmapped</string>
+                      <string>note: click Help Button/Special Keybindings for more information</string>
                      </property>
                     </widget>
                    </item>
@@ -1721,39 +1906,48 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QGroupBox" name="gb_circle">
+                 <widget class="QGroupBox" name="mouseJoystickGB">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="minimumSize">
                    <size>
-                    <width>160</width>
+                    <width>0</width>
                     <height>0</height>
                    </size>
                   </property>
                   <property name="title">
-                   <string>Circle</string>
+                   <string>Mouse to Joystick</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
-                  <layout class="QVBoxLayout" name="gb_circle_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_3">
                    <item>
-                    <widget class="QRightClickButton" name="CircleButton">
+                    <widget class="QComboBox" name="MouseJoystickBox">
                      <property name="focusPolicy">
                       <enum>Qt::FocusPolicy::NoFocus</enum>
                      </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="mouseJoystickLabel">
+                     <property name="font">
+                      <font>
+                       <italic>true</italic>
+                      </font>
+                     </property>
                      <property name="text">
-                      <string>unmapped</string>
+                      <string>*press F7 ingame to activate</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>true</bool>
                      </property>
                     </widget>
                    </item>
@@ -1762,392 +1956,106 @@
                 </item>
                </layout>
               </item>
-              <item>
-               <widget class="QWidget" name="widget_cross" native="true">
-                <layout class="QHBoxLayout" name="widget_cross_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_cross">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Cross</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_5">
-                    <item>
-                     <widget class="QRightClickButton" name="CrossButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
              </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Policy::Maximum</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="RightStickDeadZoneGB">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Right Analog Halfmode</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_13">
-              <item>
-               <widget class="QRightClickButton" name="RHalfButton">
-                <property name="focusPolicy">
-                 <enum>Qt::FocusPolicy::NoFocus</enum>
-                </property>
-                <property name="text">
-                 <string>unmapped</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_3">
-                <property name="font">
-                 <font>
-                  <italic>true</italic>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>hold to move right stick at half-speed</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gb_right_stick">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Right Stick</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_2">
-              <property name="leftMargin">
-               <number>5</number>
-              </property>
-              <property name="topMargin">
-               <number>5</number>
-              </property>
-              <property name="rightMargin">
-               <number>5</number>
-              </property>
-              <property name="bottomMargin">
-               <number>5</number>
-              </property>
-              <item>
-               <widget class="QWidget" name="widget_right_stick_up" native="true">
-                <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_right_stick_up">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>1231321</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Up</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_7">
-                    <item>
-                     <widget class="QRightClickButton" name="RStickUpButton">
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="layout_right_stick_left_right">
-                <item>
-                 <widget class="QGroupBox" name="gb_right_stick_left">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Left</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="RStickLeftButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_right_stick_right">
-                  <property name="minimumSize">
-                   <size>
-                    <width>160</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Right</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QRightClickButton" name="RStickRightButton">
-                     <property name="focusPolicy">
-                      <enum>Qt::FocusPolicy::NoFocus</enum>
-                     </property>
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QWidget" name="widget_right_stick_down" native="true">
-                <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QGroupBox" name="gb_right_stick_down">
-                   <property name="minimumSize">
-                    <size>
-                     <width>160</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>124</width>
-                     <height>2121</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Down</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_6">
-                    <item>
-                     <widget class="QRightClickButton" name="RStickDownButton">
-                      <property name="focusPolicy">
-                       <enum>Qt::FocusPolicy::NoFocus</enum>
-                      </property>
-                      <property name="text">
-                       <string>unmapped</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="footerButtonsLayout">
+          <item>
+           <widget class="QPushButton" name="HelpButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::FocusPolicy::NoFocus</enum>
+            </property>
+            <property name="text">
+             <string>Help</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="TextEditorButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::FocusPolicy::NoFocus</enum>
+            </property>
+            <property name="text">
+             <string>Text Editor</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="footerLayout">
+          <item>
+           <widget class="QLabel" name="unmapLabel">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Tip: Unmap inputs with right-click</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDialogButtonBox" name="buttonBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="standardButtons">
+             <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+            </property>
+            <property name="centerButtons">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Tip: Unmap inputs with right-click</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-       </property>
-       <property name="centerButtons">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>
@@ -2158,8 +2066,6 @@
    <header>src/qt_gui/right_click_button.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../shadps4.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
The shadPS4 input engine allows up to three unique mappings for each output, but until now you could only set one mapping in the GUI. Was never sure how to approach trying to design the UI for all those inputs, but I'm proposing simply a long scrollable list like this. This requires some scrolling from the user, but at least you can now map all the alternate inputs.

Very open to suggestions regading this.

Screenshot:

<img width="995" height="979" alt="image" src="https://github.com/user-attachments/assets/c19e26ae-c342-491e-b831-2fc2d3938a2b" />




