### PR TITLE
Bitlocker Dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,8 +271,6 @@ set(COMMON src/common/logging/classes.h
            src/common/aes.h
            src/common/assert.cpp
            src/common/assert.h
-           src/common/bitlocker.cpp
-           src/common/bitlocker.h
            src/common/bounded_threadsafe_queue.h
            src/common/versions.cpp
            src/common/versions.h
@@ -411,6 +409,13 @@ qt_add_executable(shadPS4QtLauncher
     src/images/shadPS4.icns
     src/main.cpp
 )
+
+if(WIN32)
+    target_sources(shadPS4QtLauncher PRIVATE
+            src/common/bitlocker.cpp
+            src/common/bitlocker.h
+    )
+endif()
 
 create_target_directory_groups(shadPS4QtLauncher)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,8 @@ set(COMMON src/common/logging/classes.h
            src/common/aes.h
            src/common/assert.cpp
            src/common/assert.h
+           src/common/bitlocker.cpp
+           src/common/bitlocker.h
            src/common/bounded_threadsafe_queue.h
            src/common/versions.cpp
            src/common/versions.h

--- a/src/common/bitlocker.cpp
+++ b/src/common/bitlocker.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bitlocker.h"
+
+#include <format>
+#include <string>
+
+static HMODULE hFveApi = nullptr;
+
+bool FveInit() {
+    hFveApi = LoadLibraryW(L"fveapi.dll");
+    if (!hFveApi) {
+        return false;
+    }
+
+    pOpenVolume = (_FveOpenVolumeW)GetProcAddress(hFveApi, "FveOpenVolumeW");
+    pCloseVolume = (_FveCloseVolume)GetProcAddress(hFveApi, "FveCloseVolume");
+    pAuthFromPass =
+        (_FveAuthElementFromPassPhraseW)GetProcAddress(hFveApi, "FveAuthElementFromPassPhraseW");
+    pUnlock = (_FveUnlockVolume)GetProcAddress(hFveApi, "FveUnlockVolume");
+    pGetStatus = (_FveGetStatus)GetProcAddress(hFveApi, "FveGetStatus");
+
+    return pOpenVolume && pCloseVolume && pAuthFromPass && pUnlock && pGetStatus;
+}
+
+void FveCleanup() {
+    if (hFveApi) {
+        FreeLibrary(hFveApi);
+    };
+}
+
+static HANDLE OpenVolume(PCWSTR drive) {
+    std::wstring path = std::format(LR"(\\.\{}:)", drive);
+    HANDLE handle = INVALID_HANDLE_VALUE;
+    HRESULT hr = pOpenVolume(path.c_str(), FALSE, &handle);
+    return handle;
+}
+
+bool FveIsLocked(PCWSTR drive) {
+    HANDLE handle = OpenVolume(drive);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    BYTE buffer[0x78] = {};
+    ULONG* pStatus = reinterpret_cast<ULONG*>(buffer);
+    pStatus[0] = 0x78;
+    pStatus[1] = 8;
+
+    HRESULT hr = pGetStatus(handle, reinterpret_cast<FVE_STATUS*>(buffer));
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    pCloseVolume(handle);
+    return pStatus[3] >> 0xb & 1;
+}
+
+HRESULT FveUnlock(PCWSTR drive, PCWSTR passphrase) {
+    HANDLE handle = OpenVolume(drive);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return E_HANDLE;
+    }
+
+    FVE_AUTH_ELEMENT element = {};
+    element.StructureSize = sizeof(FVE_AUTH_ELEMENT);
+    element.StructureVersion = 1;
+
+    HRESULT hr = pAuthFromPass(passphrase, &element);
+    if (SUCCEEDED(hr)) {
+        PFVE_AUTH_ELEMENT pElement = &element;
+        FVE_AUTH_INFORMATION info = {};
+        info.StructureSize = sizeof(FVE_AUTH_INFORMATION);
+        info.StructureVersion = 1;
+        info.ElementsCount = 1;
+        info.Elements = &pElement;
+        hr = pUnlock(handle, &info);
+    }
+
+    pCloseVolume(handle);
+    return hr;
+}

--- a/src/common/bitlocker.h
+++ b/src/common/bitlocker.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <windows.h>
+
+typedef struct {
+    WCHAR ClearPassPhrase[257];
+    BYTE HashedPassPhrase[32];
+    BYTE Salt[16];
+} FVE_AUTH_PASSPHRASE;
+
+typedef struct {
+    ULONG StructureSize;
+    ULONG StructureVersion;
+    ULONG ElementFlags;
+    ULONG ElementType;
+    union {
+        BYTE Nothing[1];
+        FVE_AUTH_PASSPHRASE PassPhrase;
+    } Data;
+} FVE_AUTH_ELEMENT, *PFVE_AUTH_ELEMENT;
+
+typedef struct {
+    ULONG StructureSize;
+    ULONG StructureVersion;
+    ULONG AuthFlags;
+    ULONG ElementsCount;
+    PFVE_AUTH_ELEMENT* Elements;
+    PCWSTR Description;
+    FILETIME CreationTime;
+    GUID Identifier;
+} FVE_AUTH_INFORMATION;
+
+typedef struct _FVE_STATUS_V8 {
+    ULONG StructureSize;
+    ULONG StructureVersion;
+    USHORT FveVersion;
+    ULONG Flags;
+} FVE_STATUS_V8;
+typedef FVE_STATUS_V8 FVE_STATUS;
+
+typedef HRESULT(NTAPI* _FveOpenVolumeW)(PCWSTR, BOOL, HANDLE*);
+typedef HRESULT(NTAPI* _FveCloseVolume)(HANDLE);
+typedef HRESULT(NTAPI* _FveAuthElementFromPassPhraseW)(PCWSTR, PFVE_AUTH_ELEMENT);
+typedef HRESULT(NTAPI* _FveUnlockVolume)(HANDLE, const FVE_AUTH_INFORMATION*);
+typedef HRESULT(NTAPI* _FveGetStatus)(HANDLE, FVE_STATUS*);
+
+static _FveOpenVolumeW pOpenVolume;
+static _FveCloseVolume pCloseVolume;
+static _FveAuthElementFromPassPhraseW pAuthFromPass;
+static _FveUnlockVolume pUnlock;
+static _FveGetStatus pGetStatus;
+
+bool FveInit();
+void FveCleanup();
+bool FveIsLocked(PCWSTR drive);
+HRESULT FveUnlock(PCWSTR drive, PCWSTR passphrase);

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -3,13 +3,22 @@
 
 #include <QProgressDialog>
 
+#if WIN32
+#include "common/bitlocker.h"
+#endif
+
 #include "common/path_util.h"
 #include "compatibility_info.h"
 #include "core/emulator_settings.h"
 #include "game_info.h"
 
+#include <QInputDialog>
+#include <QMessageBox>
+
 // Maximum depth to search for games in subdirectories
 const int max_recursion_depth = 5;
+
+static bool alreadyAskedBitlocker = false;
 
 void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int current_depth = 0) {
     // Stop recursion if we've reached the maximum depth
@@ -18,6 +27,45 @@ void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int cu
     }
 
     QDir directory(dir);
+
+#if WIN32
+    QFileInfo dirInfo(dir);
+    if (!dirInfo.isReadable() && !alreadyAskedBitlocker) {
+        QString drive = dir.split(":").first();
+
+        std::wstring wDrive = drive.toStdWString();
+        PCWSTR drivePtr = wDrive.c_str();
+
+        FveInit();
+
+        if (FveIsLocked(drivePtr)) {
+        promt:
+            bool ok;
+            QString key =
+                QInputDialog::getText(nullptr, QObject::tr("Drive Locked"),
+                                      QObject::tr("The drive %1: is locked. Please enter the "
+                                                  "BitLocker recovery key to access it:")
+                                          .arg(drive),
+                                      QLineEdit::Password, QString(), &ok);
+            if (!ok) {
+                alreadyAskedBitlocker = true;
+                return;
+            }
+
+            std::wstring wKey = key.toStdWString();
+
+            HRESULT hr = FveUnlock(drivePtr, wKey.c_str());
+            if (hr == 0x80310027) {
+                QMessageBox::critical(nullptr, QObject::tr("Error"),
+                                      QObject::tr("Incorrect recovery key. Please try again."));
+                goto promt;
+            }
+        }
+
+        FveCleanup();
+#endif
+    }
+
     QFileInfoList entries = directory.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
 
     for (const auto& entry : entries) {

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -43,8 +43,8 @@ void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int cu
             bool ok;
             QString key =
                 QInputDialog::getText(nullptr, QObject::tr("Drive Locked"),
-                                      QObject::tr("The drive %1: is locked. Please enter the "
-                                                  "BitLocker recovery key to access it:")
+                                      QObject::tr("Drive %1: is locked. Please enter the "
+                                                  "BitLocker key to access it:")
                                           .arg(drive),
                                       QLineEdit::Password, QString(), &ok);
             if (!ok) {

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -63,8 +63,8 @@ void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int cu
         }
 
         FveCleanup();
-#endif
     }
+#endif
 
     QFileInfoList entries = directory.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
 

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -41,12 +41,11 @@ void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int cu
         if (FveIsLocked(drivePtr)) {
         promt:
             bool ok;
-            QString key =
-                QInputDialog::getText(nullptr, QObject::tr("Drive Locked"),
-                                      QObject::tr("Drive %1: is locked. Please enter the "
-                                                  "BitLocker key to access it:")
-                                          .arg(drive),
-                                      QLineEdit::Password, QString(), &ok);
+            QString key = QInputDialog::getText(nullptr, QObject::tr("Drive Locked"),
+                                                QObject::tr("Drive %1: is locked. Please enter the "
+                                                            "BitLocker key to access it:")
+                                                    .arg(drive),
+                                                QLineEdit::Password, QString(), &ok);
             if (!ok) {
                 alreadyAskedBitlocker = true;
                 return;


### PR DESCRIPTION
When the launcher starts and the configured game path is located on a BitLocker‑protected drive, a dialog now appears prompting the user to enter the BitLocker key to unlock the drive.

