### PR TITLE
audio settings: do not save translated strings to config file that crash games

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1389,9 +1389,13 @@ void SettingsDialog::RefreshAudioDevices() {
         }
     }
 
-    ui->DsAudioComboBox->addItems(playbackDeviceList);
-    ui->GenAudioComboBox->addItems(playbackDeviceList);
-    ui->micComboBox->addItems(recordingDeviceList);
+    for (const QString& name : playbackDeviceList) {
+        ui->DsAudioComboBox->addItem(name, name);
+        ui->GenAudioComboBox->addItem(name, name);
+    }
+    for (const QString& name : recordingDeviceList) {
+        ui->micComboBox->addItem(name, name);
+    }
 
     if (backend == "SDL") {
         ui->GenAudioComboBox->setCurrentText(

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -803,18 +803,19 @@ void SettingsDialog::LoadValuesFromConfig() {
     const QString backend = ui->audioBackendComboBox->currentText();
 
     if (backend == "SDL") {
-        ui->GenAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice()));
-        ui->DsAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice()));
-        ui->micComboBox->setCurrentText(QString::fromStdString(EmulatorSettings.GetSDLMicDevice()));
+        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice())));
+        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice())));
+        ui->micComboBox->setCurrentIndex(
+            ui->micComboBox->findData(QString::fromStdString(EmulatorSettings.GetSDLMicDevice())));
     } else if (backend == "OpenAL") {
-        ui->GenAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice()));
-        ui->DsAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice()));
-        ui->micComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice()));
+        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice())));
+        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice())));
+        ui->micComboBox->setCurrentIndex(ui->micComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice())));
     }
 
     QString chooseHomeTab = m_gui_settings->GetValue(gui::gen_homeTab).toString();
@@ -1181,7 +1182,7 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
     EmulatorSettings.SetCopyGpuBuffers(ui->copyGPUBuffersCheckBox->isChecked(), is_specific);
 
     const std::string backend = ui->audioBackendComboBox->currentText().toStdString();
-    EmulatorSettings.SetAudioBackend(ui->audioBackendComboBox->currentIndex());
+    EmulatorSettings.SetAudioBackend(ui->audioBackendComboBox->currentIndex(), is_specific);
     if (backend == "SDL") {
         EmulatorSettings.SetSDLMainOutputDevice(
             ui->GenAudioComboBox->currentData().toString().toStdString(), is_specific);
@@ -1398,18 +1399,19 @@ void SettingsDialog::RefreshAudioDevices() {
     }
 
     if (backend == "SDL") {
-        ui->GenAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice()));
-        ui->DsAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice()));
-        ui->micComboBox->setCurrentText(QString::fromStdString(EmulatorSettings.GetSDLMicDevice()));
+        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice())));
+        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice())));
+        ui->micComboBox->setCurrentIndex(
+            ui->micComboBox->findData(QString::fromStdString(EmulatorSettings.GetSDLMicDevice())));
     } else if (backend == "OpenAL") {
-        ui->GenAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice()));
-        ui->DsAudioComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice()));
-        ui->micComboBox->setCurrentText(
-            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice()));
+        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice())));
+        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice())));
+        ui->micComboBox->setCurrentIndex(ui->micComboBox->findData(
+            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice())));
     }
 }
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -803,19 +803,18 @@ void SettingsDialog::LoadValuesFromConfig() {
     const QString backend = ui->audioBackendComboBox->currentText();
 
     if (backend == "SDL") {
-        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice())));
-        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice())));
-        ui->micComboBox->setCurrentIndex(
-            ui->micComboBox->findData(QString::fromStdString(EmulatorSettings.GetSDLMicDevice())));
+        ui->GenAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice()));
+        ui->DsAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice()));
+        ui->micComboBox->setCurrentText(QString::fromStdString(EmulatorSettings.GetSDLMicDevice()));
     } else if (backend == "OpenAL") {
-        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice())));
-        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice())));
-        ui->micComboBox->setCurrentIndex(ui->micComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice())));
+        ui->GenAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice()));
+        ui->DsAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice()));
+        ui->micComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice()));
     }
 
     QString chooseHomeTab = m_gui_settings->GetValue(gui::gen_homeTab).toString();
@@ -1399,19 +1398,18 @@ void SettingsDialog::RefreshAudioDevices() {
     }
 
     if (backend == "SDL") {
-        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice())));
-        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice())));
-        ui->micComboBox->setCurrentIndex(
-            ui->micComboBox->findData(QString::fromStdString(EmulatorSettings.GetSDLMicDevice())));
+        ui->GenAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetSDLMainOutputDevice()));
+        ui->DsAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetSDLPadSpkOutputDevice()));
+        ui->micComboBox->setCurrentText(QString::fromStdString(EmulatorSettings.GetSDLMicDevice()));
     } else if (backend == "OpenAL") {
-        ui->GenAudioComboBox->setCurrentIndex(ui->GenAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice())));
-        ui->DsAudioComboBox->setCurrentIndex(ui->DsAudioComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice())));
-        ui->micComboBox->setCurrentIndex(ui->micComboBox->findData(
-            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice())));
+        ui->GenAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALMainOutputDevice()));
+        ui->DsAudioComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALPadSpkOutputDevice()));
+        ui->micComboBox->setCurrentText(
+            QString::fromStdString(EmulatorSettings.GetOpenALMicDevice()));
     }
 }
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1187,15 +1187,15 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
             ui->GenAudioComboBox->currentData().toString().toStdString(), is_specific);
         EmulatorSettings.SetSDLPadSpkOutputDevice(
             ui->DsAudioComboBox->currentData().toString().toStdString(), is_specific);
-        EmulatorSettings.SetSDLMicDevice(
-            ui->micComboBox->currentData().toString().toStdString(), is_specific);
+        EmulatorSettings.SetSDLMicDevice(ui->micComboBox->currentData().toString().toStdString(),
+                                         is_specific);
     } else if (backend == "OpenAL") {
         EmulatorSettings.SetOpenALMainOutputDevice(
             ui->GenAudioComboBox->currentData().toString().toStdString(), is_specific);
         EmulatorSettings.SetOpenALPadSpkOutputDevice(
             ui->DsAudioComboBox->currentData().toString().toStdString(), is_specific);
-        EmulatorSettings.SetOpenALMicDevice(
-            ui->micComboBox->currentData().toString().toStdString(), is_specific);
+        EmulatorSettings.SetOpenALMicDevice(ui->micComboBox->currentData().toString().toStdString(),
+                                            is_specific);
     }
 
     // Entries with no game-specific settings

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1183,18 +1183,19 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
     const std::string backend = ui->audioBackendComboBox->currentText().toStdString();
     EmulatorSettings.SetAudioBackend(ui->audioBackendComboBox->currentIndex());
     if (backend == "SDL") {
-        EmulatorSettings.SetSDLMainOutputDevice(ui->GenAudioComboBox->currentText().toStdString(),
-                                                is_specific);
-        EmulatorSettings.SetSDLPadSpkOutputDevice(ui->DsAudioComboBox->currentText().toStdString(),
-                                                  is_specific);
-        EmulatorSettings.SetSDLMicDevice(ui->micComboBox->currentText().toStdString(), is_specific);
+        EmulatorSettings.SetSDLMainOutputDevice(
+            ui->GenAudioComboBox->currentData().toString().toStdString(), is_specific);
+        EmulatorSettings.SetSDLPadSpkOutputDevice(
+            ui->DsAudioComboBox->currentData().toString().toStdString(), is_specific);
+        EmulatorSettings.SetSDLMicDevice(
+            ui->micComboBox->currentData().toString().toStdString(), is_specific);
     } else if (backend == "OpenAL") {
         EmulatorSettings.SetOpenALMainOutputDevice(
-            ui->GenAudioComboBox->currentText().toStdString(), is_specific);
+            ui->GenAudioComboBox->currentData().toString().toStdString(), is_specific);
         EmulatorSettings.SetOpenALPadSpkOutputDevice(
-            ui->DsAudioComboBox->currentText().toStdString(), is_specific);
-        EmulatorSettings.SetOpenALMicDevice(ui->micComboBox->currentText().toStdString(),
-                                            is_specific);
+            ui->DsAudioComboBox->currentData().toString().toStdString(), is_specific);
+        EmulatorSettings.SetOpenALMicDevice(
+            ui->micComboBox->currentData().toString().toStdString(), is_specific);
     }
 
     // Entries with no game-specific settings

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -240,6 +240,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     if (!SDL_Init(SDL_INIT_AUDIO)) {
         LOG_ERROR(Config, "SDL_INIT_AUDIO failed: {}", SDL_GetError());
     }
+    ui->audioBackendComboBox->setCurrentIndex(EmulatorSettings.GetAudioBackend());
     RefreshAudioDevices();
 
     InitializeEmulatorLanguages();


### PR DESCRIPTION
Fixes saving of translated string in to the config file that caused some games to crash. fe. Driveclub
`+`  logic for correct setting loading.