### PR TITLE
More robust save and trophy migration logic

### DIFF
--- a/src/core/user_manager.cpp
+++ b/src/core/user_manager.cpp
@@ -3,19 +3,13 @@
 
 #include <filesystem>
 #include <iostream>
-#include <QFile>
-#include <QMessageBox>
-#include <QXmlStreamReader>
 #include <common/assert.h>
 #include <common/path_util.h>
 #include "emulator_settings.h"
-#include "qt_gui/main_window.h"
 #include "user_manager.h"
 #include "user_settings.h"
 
 namespace fs = std::filesystem;
-
-#define tr(...) MainWindow::tr(__VA_ARGS__)
 
 bool UserManager::AddUser(const User& user) {
     for (const auto& u : m_users.user) {
@@ -93,170 +87,6 @@ const std::vector<User>& UserManager::GetAllUsers() const {
     return m_users.user;
 }
 
-enum class TransferOption : s32 {
-    Copy = 0,
-    Move,
-    MoveAndLinkBack,
-    Nothing,
-    SdlCancelled = -1,
-};
-TransferOption AskMigrationOption(QWidget* parent = nullptr) {
-    QMessageBox msgbox(parent);
-
-    // clang-format off
-    msgbox.setWindowTitle(tr("Save/Trophy Migration"));
-#ifdef _WIN32
-    msgbox.setText(tr("The shadPS4 save and trophy locations have been updated, and save/trophy files have been detected in the old location.\n") +
-                   tr("Do you wish to copy them over, move them over, or continue without doing anything?"));
-#else
-    msgbox.setText(tr("The shadPS4 save and trophy locations have been updated, and save/trophy files have been detected in the old location.\n") +
-                   tr("Do you wish to copy them over, move them over, move and link back to the original location, or continue without doing anything?"));
-#endif
-    // clang-format on
-
-    auto* copy_btn = (QAbstractButton*)msgbox.addButton("Copy", QMessageBox::AcceptRole);
-    auto* move_btn = (QAbstractButton*)msgbox.addButton("Move", QMessageBox::AcceptRole);
-
-#ifndef _WIN32
-    auto* link_btn =
-        (QAbstractButton*)msgbox.addButton("Move and link back", QMessageBox::AcceptRole);
-#endif
-
-    auto* nothing_btn = (QAbstractButton*)msgbox.addButton("Do nothing", QMessageBox::RejectRole);
-
-    msgbox.exec();
-
-    auto* clicked = msgbox.clickedButton();
-
-    if (clicked == copy_btn)
-        return TransferOption::Copy;
-
-    if (clicked == move_btn)
-        return TransferOption::Move;
-
-#ifndef _WIN32
-    if (clicked == link_btn)
-        return TransferOption::MoveAndLinkBack;
-#endif
-
-    return TransferOption::Nothing;
-}
-
-static void MoveFolder(fs::path const& _from, fs::path const& _to) {
-    try {
-        fs::rename(_from, _to);
-    } catch (...) {
-        fs::copy(_from, _to, fs::copy_options::recursive);
-        fs::remove_all(_from);
-    }
-}
-
-static void CheckAndMigrateSaves(TransferOption option) {
-    auto const new_save_dir = EmulatorSettings.GetHomeDir() / "1000" / "savedata";
-    auto const old_save_dir =
-        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "savedata" / "1";
-    if (fs::exists(old_save_dir) && !fs::is_empty(old_save_dir)) {
-        try {
-            switch (option) {
-            case TransferOption::Copy:
-                fs::copy(old_save_dir, new_save_dir, fs::copy_options::recursive);
-                break;
-            case TransferOption::Move:
-                MoveFolder(old_save_dir, new_save_dir);
-                break;
-            case TransferOption::MoveAndLinkBack:
-                MoveFolder(old_save_dir, new_save_dir);
-                fs::create_directory_symlink(new_save_dir, old_save_dir);
-                break;
-            case TransferOption::SdlCancelled:
-            case TransferOption::Nothing:
-                break;
-            default:
-                UNREACHABLE();
-            }
-        } catch (std::exception const& e) {
-            UNREACHABLE_MSG("Error while migrating saves: {}", e.what());
-        }
-    }
-}
-
-static void CheckAndMigrateTrophies(TransferOption option) {
-    auto const user_dir = EmulatorSettings.GetHomeDir() / "1000";
-    auto const old_trophy_base_dir =
-        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data";
-    auto const new_trophy_global_dir =
-        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "trophy";
-    try {
-        for (auto const& entry : fs::directory_iterator(old_trophy_base_dir)) {
-            if (!entry.is_directory()) {
-                continue;
-            }
-            if (!fs::exists(entry.path() / "TrophyFiles")) {
-                continue;
-            }
-            for (auto const& subentry : fs::directory_iterator(entry.path() / "TrophyFiles")) {
-                if (!subentry.is_directory()) {
-                    continue;
-                }
-                auto const old_trophy_dir = subentry.path();
-                if (fs::exists(old_trophy_dir / "Xml")) {
-                    QFile file(
-                        QString::fromStdString((old_trophy_dir / "Xml" / "TROP.XML").string()));
-                    if (!file.open(QIODevice::ReadOnly)) {
-                        continue;
-                    }
-
-                    QXmlStreamReader xml(&file);
-
-                    std::string npcommid;
-
-                    while (!xml.atEnd()) {
-                        xml.readNext();
-
-                        if (xml.isStartElement() && xml.name() == u"npcommid") {
-                            npcommid = xml.readElementText().toStdString();
-                            break;
-                        }
-                    }
-
-                    if (xml.hasError() || npcommid.empty()) {
-                        continue;
-                    }
-                    if (fs::exists(user_dir / "trophy" / (npcommid + ".xml"))) {
-                        continue;
-                    }
-                    if (!fs::exists(new_trophy_global_dir / npcommid)) {
-                        fs::create_directories(new_trophy_global_dir / npcommid);
-                        fs::copy(old_trophy_dir, new_trophy_global_dir / npcommid,
-                                 fs::copy_options::recursive);
-                    }
-                    auto const old_trophy_file = old_trophy_dir / "Xml" / "TROP.XML";
-                    auto const new_trophy_file = user_dir / "trophy" / (npcommid + ".xml");
-                    switch (option) {
-                    case TransferOption::Copy:
-                        fs::copy_file(old_trophy_file, new_trophy_file);
-                        break;
-                    case TransferOption::Move:
-                        MoveFolder(old_trophy_file, new_trophy_file);
-                        break;
-                    case TransferOption::MoveAndLinkBack:
-                        MoveFolder(old_trophy_file, new_trophy_file);
-                        fs::create_symlink(new_trophy_file, old_trophy_file);
-                        break;
-                    case TransferOption::Nothing:
-                    case TransferOption::SdlCancelled:
-                        break;
-                    default:
-                        UNREACHABLE();
-                    }
-                }
-            }
-        }
-    } catch (std::exception const& e) {
-        UNREACHABLE_MSG("Error while migrating trophies: {}", e.what());
-    }
-}
-
 Users UserManager::CreateDefaultUsers() {
     Users default_users;
     default_users.user = {
@@ -314,11 +144,6 @@ Users UserManager::CreateDefaultUsers() {
             std::filesystem::create_directory(user_dir / "savedata");
             std::filesystem::create_directory(user_dir / "trophy");
             std::filesystem::create_directory(user_dir / "inputs");
-            if (u.user_id == 1000) {
-                TransferOption user_choice = AskMigrationOption();
-                CheckAndMigrateSaves(user_choice);
-                CheckAndMigrateTrophies(user_choice);
-            }
         }
     }
 

--- a/src/core/user_settings.cpp
+++ b/src/core/user_settings.cpp
@@ -5,12 +5,218 @@
 #include <fstream>
 #include <iomanip>
 #include <map>
+#include <QFile>
+#include <QMessageBox>
+#include <QXmlStreamReader>
 #include <common/path_util.h>
 #include <common/scm_rev.h>
+#include "common/assert.h"
 #include "common/logging/log.h"
+#include "qt_gui/main_window.h"
 #include "user_settings.h"
 
 using json = nlohmann::json;
+
+namespace fs = std::filesystem;
+
+#define tr(...) MainWindow::tr(__VA_ARGS__)
+
+enum class TransferOption : s32 {
+    Copy = 0,
+    Move,
+    MoveAndLinkBack,
+    Nothing,
+    SdlCancelled = -1,
+};
+
+TransferOption AskMigrationOption(QWidget* parent = nullptr) {
+    QMessageBox msgbox(parent);
+
+    // clang-format off
+    msgbox.setWindowTitle(tr("Save/Trophy Migration"));
+#ifdef _WIN32
+    msgbox.setText(tr("The shadPS4 save and trophy locations have been updated, and save/trophy files have been detected in the old location.\n") +
+                   tr("Do you wish to copy them over, move them over, or continue without doing anything?"));
+#else
+    msgbox.setText(tr("The shadPS4 save and trophy locations have been updated, and save/trophy files have been detected in the old location.\n") +
+                   tr("Do you wish to copy them over, move them over, move and link back to the original location, or continue without doing anything?"));
+#endif
+    // clang-format on
+
+    auto* copy_btn = (QAbstractButton*)msgbox.addButton("Copy", QMessageBox::AcceptRole);
+    auto* move_btn = (QAbstractButton*)msgbox.addButton("Move", QMessageBox::AcceptRole);
+
+#ifndef _WIN32
+    auto* link_btn =
+        (QAbstractButton*)msgbox.addButton("Move and link back", QMessageBox::AcceptRole);
+#endif
+
+    auto* nothing_btn = (QAbstractButton*)msgbox.addButton("Do nothing", QMessageBox::RejectRole);
+
+    msgbox.exec();
+
+    auto* clicked = msgbox.clickedButton();
+
+    if (clicked == copy_btn)
+        return TransferOption::Copy;
+
+    if (clicked == move_btn)
+        return TransferOption::Move;
+
+#ifndef _WIN32
+    if (clicked == link_btn)
+        return TransferOption::MoveAndLinkBack;
+#endif
+
+    return TransferOption::Nothing;
+}
+
+static void MovePath(fs::path const& _from, fs::path const& _to) {
+    try {
+        fs::rename(_from, _to);
+    } catch (...) {
+        fs::copy(_from, _to, fs::copy_options::recursive | fs::copy_options::skip_existing);
+        // no delete to avoid data loss
+    }
+}
+
+static void CheckAndMigrateSaves(TransferOption option) {
+    auto const new_save_root = EmulatorSettings.GetHomeDir() / "1000" / "savedata";
+    auto const old_save_root =
+        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "savedata" / "1";
+    try {
+        for (const auto& entry : fs::directory_iterator(old_save_root)) {
+            if (!entry.is_directory()) {
+                continue;
+            }
+            const auto old_game_dir = entry.path();
+            const auto new_game_dir = new_save_root / old_game_dir.filename();
+            const bool already_exists = fs::exists(new_game_dir);
+
+            switch (option) {
+            case TransferOption::Copy:
+                if (!already_exists) {
+                    fs::copy(old_game_dir, new_game_dir, fs::copy_options::recursive);
+                }
+                break;
+            case TransferOption::Move:
+                if (!already_exists) {
+                    MovePath(old_game_dir, new_game_dir);
+                }
+                break;
+            case TransferOption::MoveAndLinkBack:
+                if (!already_exists) {
+                    MovePath(old_game_dir, new_game_dir);
+                    fs::create_directory_symlink(new_game_dir, old_game_dir);
+                }
+                break;
+            case TransferOption::Nothing:
+            case TransferOption::SdlCancelled:
+                return;
+            default:
+                UNREACHABLE();
+            }
+        }
+    } catch (std::exception const& e) {
+        UNREACHABLE_MSG("Error while migrating saves: {}", e.what());
+    }
+}
+
+static void CheckAndMigrateTrophies(TransferOption option) {
+    const auto user_dir = EmulatorSettings.GetHomeDir() / "1000";
+    const auto old_trophy_base_dir =
+        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data";
+    const auto new_trophy_global_dir =
+        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "trophy";
+    if (!fs::exists(old_trophy_base_dir)) {
+        return;
+    }
+
+    for (const auto& entry : fs::directory_iterator(old_trophy_base_dir)) {
+        if (!entry.is_directory()) {
+            continue;
+        }
+
+        const auto trophy_files_dir = entry.path() / "TrophyFiles";
+        if (!fs::exists(trophy_files_dir)) {
+            continue;
+        }
+
+        for (const auto& subentry : fs::directory_iterator(trophy_files_dir)) {
+            if (!subentry.is_directory()) {
+                continue;
+            }
+
+            const auto old_trophy_dir = subentry.path();
+            const auto xml_path = old_trophy_dir / "Xml" / "TROP.XML";
+            if (!fs::exists(xml_path)) {
+                continue;
+            }
+
+            QFile file(QString::fromStdString(xml_path.string()));
+            if (!file.open(QIODevice::ReadOnly)) {
+                continue;
+            }
+
+            QXmlStreamReader xml(&file);
+            std::string npcommid;
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.isStartElement() && xml.name() == u"npcommid") {
+                    npcommid = xml.readElementText().toStdString();
+                    break;
+                }
+            }
+
+            if (xml.hasError() || npcommid.empty()) {
+                continue;
+            }
+
+            const auto new_trophy_file = user_dir / "trophy" / (npcommid + ".xml");
+            if (fs::exists(new_trophy_file)) {
+                continue;
+            }
+
+            const auto new_trophy_dir = new_trophy_global_dir / npcommid;
+            if (!fs::exists(new_trophy_dir)) {
+                fs::copy(old_trophy_dir, new_trophy_dir, fs::copy_options::recursive);
+            }
+
+            switch (option) {
+            case TransferOption::Copy:
+                fs::copy_file(xml_path, new_trophy_file);
+                break;
+            case TransferOption::Move:
+                MovePath(xml_path, new_trophy_file);
+                break;
+            case TransferOption::MoveAndLinkBack:
+                MovePath(xml_path, new_trophy_file);
+                fs::create_symlink(new_trophy_file, xml_path);
+                break;
+            case TransferOption::Nothing:
+            case TransferOption::SdlCancelled:
+                return;
+            default:
+                UNREACHABLE();
+            }
+        }
+    }
+}
+
+void CheckSaveAndTrophyMigration() {
+    auto const migration_done_path =
+        EmulatorSettings.GetHomeDir() / "1000" / "savedata" / ".data_transfer.complete";
+    auto const old_save_dir =
+        Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "savedata" / "1";
+    if (fs::exists(old_save_dir) && !fs::is_empty(old_save_dir) &&
+        !fs::exists(migration_done_path)) {
+        TransferOption user_choice = AskMigrationOption();
+        CheckAndMigrateSaves(user_choice);
+        CheckAndMigrateTrophies(user_choice);
+        std::ofstream ofs(migration_done_path);
+        ofs << "";
+    }
+}
 
 // Singleton storage
 std::shared_ptr<UserSettingsImpl> UserSettingsImpl::s_instance = nullptr;
@@ -65,6 +271,7 @@ bool UserSettingsImpl::Load() {
                 m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
             }
             Save(); // Save default users
+            CheckSaveAndTrophyMigration();
             return false;
         }
 
@@ -98,6 +305,7 @@ bool UserSettingsImpl::Load() {
         }
 
         LOG_DEBUG(Config, "User settings loaded successfully");
+        CheckSaveAndTrophyMigration();
         return true;
     } catch (const std::exception& e) {
         LOG_ERROR(Config, "Error loading user settings: {}", e.what());
@@ -105,6 +313,7 @@ bool UserSettingsImpl::Load() {
         if (m_userManager.GetUsers().user.empty()) {
             m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
         }
+        CheckSaveAndTrophyMigration();
         return false;
     }
 }


### PR DESCRIPTION
Now the save migration popup depends on whether you have a `.data_transfer.complete` file in `home/1000/savedata` instead of only triggering on the home/ folder's creation. It also only transfers saves/trophies that don't have a corresponding version already in the new location.