### PR TITLE
Set base folder for launcher updates to the executable's parent path instead of the current working directory

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <filesystem>
+#include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
@@ -409,8 +410,10 @@ void CheckUpdate::Install() {
     QString userPath;
     Common::FS::PathToQString(userPath, Common::FS::GetUserPath(Common::FS::PathType::UserDir));
 
-    QString rootPath;
+    QString rootPath = QCoreApplication::applicationDirPath();
+#ifdef Q_OS_MACOS
     Common::FS::PathToQString(rootPath, std::filesystem::current_path());
+#endif
 
     QString tempDirPath = userPath + "/temp_download_update";
     QString startingUpdate = tr("Starting Update...");

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -567,7 +567,7 @@ tr("First you need to choose a location to save the versions in\n'Path to save v
                                             .arg(scriptFilePath);
                         process = "powershell.exe";
                         args << "-ExecutionPolicy" << "Bypass" << "-File" << scriptFilePath;
-#elif defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+#else
                     scriptFilePath = userPath + "/extract_update.sh";
                     scriptContent = QString(
                                         "#!/bin/bash\n"


### PR DESCRIPTION
Apparently, QCoreApplication::applicationDirPath will return a path inside the app bundle on macOS, so I've left the old code in place only there. Should resolve issues with autoupdating on Linux.