### PR TITLE
Fix Linux autoupdate for real this time

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -411,6 +411,12 @@ void CheckUpdate::Install() {
     Common::FS::PathToQString(userPath, Common::FS::GetUserPath(Common::FS::PathType::UserDir));
 
     QString rootPath = QCoreApplication::applicationDirPath();
+#ifdef Q_OS_LINUX
+    const char* appimage_path = std::getenv("APPIMAGE");
+    if (appimage_path) {
+        rootPath = QString(std::filesystem::path(appimage_path).parent_path().c_str());
+    }
+#endif
 #ifdef Q_OS_MACOS
     Common::FS::PathToQString(rootPath, std::filesystem::current_path());
 #endif


### PR DESCRIPTION
QCoreApplication::applicationDirPath apparently also doesn't work with Appimages either, and using this environment variable is the official way of getting the original appimage location.