### PR TITLE
mac: Updates for MoltenVK removal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
         variant: sccache
 
     - name: Configure CMake
-      run: cmake --fresh -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DENABLE_UPDATER=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+      run: cmake --fresh -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DENABLE_UPDATER=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --parallel $(sysctl -n hw.ncpu)

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 	path = externals/json
 	url = https://github.com/nlohmann/json.git
 	branch = develop
-[submodule "externals/MoltenVK"]
-	path = externals/MoltenVK
-	url = https://github.com/shadPS4-emu/ext-MoltenVK.git
 [submodule "externals/openal-soft"]
 	path = externals/openal-soft
 	url = https://github.com/shadexternals/openal-soft.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 if(APPLE)
     list(APPEND ADDITIONAL_LANGUAGES OBJC)
-    # Starting with 15.4, Rosetta 2 has support for all the necessary instruction sets.
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 15.4 CACHE STRING "")
+    # Tracks the minimum for the main emulator.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 26.0 CACHE STRING "")
 endif()
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -34,35 +34,6 @@ if(UNIX AND NOT APPLE)
 endif()
 
 option(ENABLE_UPDATER "Enables the options to updater" ON)
-
-# First, determine whether to use CMAKE_OSX_ARCHITECTURES or CMAKE_SYSTEM_PROCESSOR.
-if (APPLE AND CMAKE_OSX_ARCHITECTURES)
-    set(BASE_ARCHITECTURE "${CMAKE_OSX_ARCHITECTURES}")
-elseif (CMAKE_SYSTEM_PROCESSOR)
-    set(BASE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
-else()
-    set(BASE_ARCHITECTURE "${CMAKE_HOST_SYSTEM_PROCESSOR}")
-endif()
-
-# Next, match common architecture strings down to a known common value.
-if (BASE_ARCHITECTURE MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
-    set(ARCHITECTURE "x86_64")
-elseif (BASE_ARCHITECTURE MATCHES "(aarch64)|(AARCH64)|(arm64)|(ARM64)")
-    set(ARCHITECTURE "arm64")
-else()
-    message(FATAL_ERROR "Unsupported CPU architecture: ${BASE_ARCHITECTURE}")
-endif()
-
-if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
-    # Exclude ARM homebrew path to avoid conflicts when cross compiling.
-    list(APPEND CMAKE_IGNORE_PREFIX_PATH "/opt/homebrew")
-
-    # Need to reconfigure pkg-config to use the right architecture library paths.
-    # It's not ideal to override these but otherwise the build breaks just by having pkg-config installed.
-    set(ENV{PKG_CONFIG_DIR} "")
-    set(ENV{PKG_CONFIG_LIBDIR} "${CMAKE_SYSROOT}/usr/lib/pkgconfig:${CMAKE_SYSROOT}/usr/share/pkgconfig:${CMAKE_SYSROOT}/usr/local/lib/pkgconfig:${CMAKE_SYSROOT}/usr/local/share/pkgconfig")
-    set(ENV{PKG_CONFIG_SYSROOT_DIR} ${CMAKE_SYSROOT})
-endif()
 
 # This function should be passed a list of all files in a target. It will automatically generate file groups
 # following the directory hierarchy, so that the layout of the files in IDEs matches the one in the filesystem.
@@ -227,15 +198,6 @@ find_package(VulkanHeaders 1.4.329 CONFIG)
 find_package(OpenAL CONFIG)
 list(POP_BACK CMAKE_MODULE_PATH)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    # libc++ requires -fexperimental-library to enable std::jthread and std::stop_token support.
-    include(CheckCXXSymbolExists)
-    check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
-    if(LIBCPP)
-        add_compile_options(-fexperimental-library)
-    endif()
-endif()
-
 add_subdirectory(externals)
 include_directories(src)
 
@@ -397,6 +359,13 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            ${UPDATER}
 )
 
+if (APPLE)
+    set(QT_GUI ${QT_GUI}
+               src/qt_gui/apple.h
+               src/qt_gui/apple.mm
+    )
+endif()
+
 set(IPC src/ipc/ipc_client.cpp
         src/ipc/ipc_client.h
 )
@@ -419,34 +388,9 @@ endif()
 
 create_target_directory_groups(shadPS4QtLauncher)
 
-target_link_libraries(shadPS4QtLauncher PRIVATE Vulkan::Headers fmt::fmt toml11::toml11 SDL3::SDL3 volk_headers spdlog::spdlog)
-
-if (APPLE)
-    # Include MoltenVK, along with an ICD file so it can be found by the system Vulkan loader if used for loading layers.
-    set(MVK_BUNDLE_PATH "Resources/vulkan/icd.d")
-    set_property(TARGET shadPS4QtLauncher APPEND PROPERTY BUILD_RPATH "@executable_path/../${MVK_BUNDLE_PATH}")
-    set(MVK_DST ${CMAKE_CURRENT_BINARY_DIR}/shadPS4QtLauncher.app/Contents/${MVK_BUNDLE_PATH})
-
-    add_custom_command(
-        OUTPUT ${MVK_DST}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${MVK_DST})
-
-    set(MVK_DYLIB_SRC ${CMAKE_CURRENT_BINARY_DIR}/externals/MoltenVK/MoltenVK/libMoltenVK.dylib)
-    set(MVK_DYLIB_DST ${MVK_DST}/libMoltenVK.dylib)
-    set(MVK_ICD_SRC ${CMAKE_CURRENT_SOURCE_DIR}/externals/MoltenVK/MoltenVK/icd/MoltenVK_icd.json)
-    set(MVK_ICD_DST ${MVK_DST}/MoltenVK_icd.json)
-
-    add_custom_command(
-        OUTPUT ${MVK_ICD_DST}
-        DEPENDS ${MVK_ICD_SRC} ${MVK_DST}
-        COMMAND ${CMAKE_COMMAND} -E copy ${MVK_ICD_SRC} ${MVK_ICD_DST})
-    add_custom_command(
-        OUTPUT ${MVK_DYLIB_DST}
-        DEPENDS ${MVK_DYLIB_SRC} ${MVK_DST}
-        COMMAND ${CMAKE_COMMAND} -E copy ${MVK_DYLIB_SRC} ${MVK_DYLIB_DST})
-    add_custom_target(CopyMoltenVK DEPENDS ${MVK_ICD_DST} ${MVK_DYLIB_DST})
-    add_dependencies(CopyMoltenVK MoltenVK)
-    add_dependencies(shadPS4QtLauncher CopyMoltenVK)
+target_link_libraries(shadPS4QtLauncher PRIVATE fmt::fmt toml11::toml11 SDL3::SDL3 spdlog::spdlog)
+if (NOT APPLE)
+    target_link_libraries(shadPS4QtLauncher PRIVATE Vulkan::Headers volk_headers)
 endif()
 
 target_link_libraries(shadPS4QtLauncher PRIVATE Qt6::Widgets Qt6::Concurrent Qt6::Network Qt6::Multimedia nlohmann_json::nlohmann_json OpenAL::OpenAL)

--- a/documents/building-macos.md
+++ b/documents/building-macos.md
@@ -5,38 +5,24 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 ## Build shadPS4QtLauncher for macOS
 
-### Install the necessary tools to build shadPS4QtLauncher:
+### Install the necessary tools and dependencies to build shadPS4QtLauncher:
 
-First, make sure you have **Xcode 16.0 or newer** installed.
+First, make sure you have **Xcode 26.0 or newer** installed.
 
 For installing other tools and library dependencies we will be using [Homebrew](https://brew.sh/).
 
-On an ARM system, we will need the native ARM Homebrew to install tools and x86_64 Homebrew to install libraries.
-
-First, install native Homebrew and tools:
+First, install Homebrew:
 ```
-# Installs native Homebrew to /opt/homebrew
+# Installs Homebrew to /opt/homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 # Adds Homebrew to your path
 echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> ~/.zprofile
 eval $(/opt/homebrew/bin/brew shellenv)
-# Installs tools.
-brew install clang-format cmake
 ```
 
-Next, install x86_64 Qt. You can skip these steps and move on to **Cloning and compiling** if you do not intend to build the Qt GUI.
-
-**If you are on an ARM Mac:**
+Then, use Homebrew to install the required build tools and dependencies:
 ```
-# Installs x86_64 Homebrew to /usr/local
-arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# Installs libraries.
-arch -x86_64 /usr/local/bin/brew install qt@6
-```
-
-**If you are on an x86_64 Mac:**
-```
-brew install qt@6
+brew install clang-format cmake qt@6
 ```
 
 ### Cloning and compiling:
@@ -49,23 +35,21 @@ cd shadPS4-qtlauncher
 
 Generate the build directory in the shadPS4-qtlauncher directory:
 ```
-cmake -S . -B build/ -DCMAKE_OSX_ARCHITECTURES=x86_64
+cmake -S . -B build/
 ```
-
-If you want to build the Qt GUI, add `-DENABLE_QT_GUI=ON` to the end of this command as well.
 
 Enter the directory:
 ```
 cd build/
 ```
 
-Use make to build the project:
+Use cmake to build the project:
 ```
 cmake --build . --parallel$(sysctl -n hw.ncpu)
 ```
 
-Now run the emulator:
+Now run the launcher:
 
 ```
-./shadps4 /"PATH"/"TO"/"GAME"/"FOLDER"/eboot.bin
+./shadPS4QtLauncher.app/Contents/MacOS/shadPS4QtLauncher
 ```

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -37,12 +37,6 @@ if (NOT TARGET SDL3::SDL3)
     add_subdirectory(sdl3)
 endif()
 
-# vulkan-headers
-if (NOT TARGET Vulkan::Headers)
-    set(VULKAN_HEADERS_ENABLE_MODULE OFF)
-    add_subdirectory(vulkan-headers)
-endif()
-
 # Toml11
 if (NOT TARGET toml11::toml11)
     add_subdirectory(toml11)
@@ -92,15 +86,13 @@ endif()
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 add_subdirectory(json)
 
-#volk
-add_subdirectory(volk)
-
-# Apple-only dependencies
-if (APPLE)
-    # MoltenVK
-    if (NOT TARGET MoltenVK)
-        set(MVK_EXCLUDE_CEREAL ON)
-        set(MVK_EXCLUDE_SPIRV_TOOLS ON)
-        add_subdirectory(MoltenVK)
+if (NOT APPLE)
+    # vulkan-headers
+    if (NOT TARGET Vulkan::Headers)
+        set(VULKAN_HEADERS_ENABLE_MODULE OFF)
+        add_subdirectory(vulkan-headers)
     endif()
+
+    #volk
+    add_subdirectory(volk)
 endif()

--- a/src/qt_gui/apple.h
+++ b/src/qt_gui/apple.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+std::string GetAppleGpuName();

--- a/src/qt_gui/apple.mm
+++ b/src/qt_gui/apple.mm
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "apple.h"
+
+#include <Metal/Metal.h>
+
+std::string GetAppleGpuName() {
+    @autoreleasepool {
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        std::string name([device.name UTF8String]);
+        return name;
+    }
+}

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -27,11 +27,13 @@
 #include "sdl_event_wrapper.h"
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"
-// #include "video_core/renderer_vulkan/vk_instance.h"
-// #include "video_core/renderer_vulkan/vk_presenter.h"
 
+#ifndef __APPLE__
 #define VOLK_IMPLEMENTATION
 #include "volk.h"
+#else
+#include "qt_gui/apple.h"
+#endif
 
 // extern std::unique_ptr<Vulkan::Presenter> presenter;
 
@@ -1415,6 +1417,7 @@ void SettingsDialog::RefreshAudioDevices() {
 }
 
 void SettingsDialog::GetPhysicalDevices() {
+#ifndef __APPLE__
     if (volkInitialize() != VK_SUCCESS) {
         qWarning() << "Failed to initialize Volk.";
         return;
@@ -1432,33 +1435,6 @@ void SettingsDialog::GetPhysicalDevices() {
     VkInstanceCreateInfo instInfo{};
     instInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instInfo.pApplicationInfo = &appInfo;
-
-#ifdef __APPLE__
-    const char* portabilityExtensionName = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
-    const size_t portabilityExtensionNameLength = strlen(portabilityExtensionName);
-
-    uint32_t instanceExtensionCount = 0;
-    vkEnumerateInstanceExtensionProperties(nullptr, &instanceExtensionCount, nullptr);
-
-    if (instanceExtensionCount != 0) {
-        std::vector<VkExtensionProperties> instanceExtensions(instanceExtensionCount);
-        vkEnumerateInstanceExtensionProperties(nullptr, &instanceExtensionCount,
-                                               instanceExtensions.data());
-
-        const auto portabilityExtension = std::ranges::find_if(
-            instanceExtensions, [&portabilityExtensionName, &portabilityExtensionNameLength](
-                                    const VkExtensionProperties& ext) {
-                return strncmp(ext.extensionName, portabilityExtensionName,
-                               portabilityExtensionNameLength) == 0;
-            });
-
-        if (portabilityExtension != instanceExtensions.end()) {
-            instInfo.ppEnabledExtensionNames = &portabilityExtensionName;
-            instInfo.enabledExtensionCount = 1;
-            instInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-        }
-    }
-#endif
 
     VkInstance instance;
     if (vkCreateInstance(&instInfo, nullptr, &instance) != VK_SUCCESS) {
@@ -1489,4 +1465,9 @@ void SettingsDialog::GetPhysicalDevices() {
     }
 
     vkDestroyInstance(instance, nullptr);
+#else
+    // Apple devices have a single GPU, query its name.
+    std::string gpuName = GetAppleGpuName();
+    m_physical_devices.push_back(QString::fromStdString(gpuName));
+#endif
 }


### PR DESCRIPTION
* Update builds for minimum requirements: macOS 26 on ARM.
* Remove MoltenVK submodule and exclude Vulkan dependencies for macOS build. Rather than adding in KosmicKrisp to bundle, we can just query the single GPU name from Metal directly as it's trivial.
* Remove misc macOS-related build logic that is not needed.
* Update macOS build instructions.