### PR TITLE
Drag and Drop support on main window

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1281,8 +1281,7 @@ void MainWindow::dropEvent(QDropEvent* event) {
     isExecutable = filePath.endsWith(".exe", Qt::CaseInsensitive);
 #else
     QFileInfo info(filePath);
-    isExecutable = info.isExecutable() ||
-                   filePath.endsWith(".AppImage", Qt::CaseInsensitive) ||
+    isExecutable = info.isExecutable() || filePath.endsWith(".AppImage", Qt::CaseInsensitive) ||
                    filePath.endsWith(".appimage", Qt::CaseInsensitive);
 #endif
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1288,7 +1288,7 @@ void MainWindow::dropEvent(QDropEvent* event) {
 
     if (!isExecutable)
         return;
-
+    // if a executable is dropped, launch version control
     event->acceptProposedAction();
     auto versionDialog = new VersionDialog(m_gui_settings, this);
     versionDialog->addExecutableFromDrop(filePath);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1269,6 +1269,33 @@ void MainWindow::resizeEvent(QResizeEvent* event) {
     QMainWindow::resizeEvent(event);
 }
 
+void MainWindow::dropEvent(QDropEvent* event) {
+    const auto urls = event->mimeData()->urls();
+    if (urls.isEmpty())
+        return;
+
+    QString filePath = urls.first().toLocalFile();
+    bool isExecutable = false;
+
+#ifdef Q_OS_WIN
+    isExecutable = filePath.endsWith(".exe", Qt::CaseInsensitive);
+#else
+    QFileInfo info(filePath);
+    isExecutable = info.isExecutable() ||
+                   filePath.endsWith(".AppImage", Qt::CaseInsensitive) ||
+                   filePath.endsWith(".appimage", Qt::CaseInsensitive);
+#endif
+
+    if (!isExecutable)
+        return;
+
+    event->acceptProposedAction();
+    auto versionDialog = new VersionDialog(m_gui_settings, this);
+    versionDialog->addExecutableFromDrop(filePath);
+    connect(versionDialog, &QDialog::finished, this, [this](int) { LoadVersionComboBox(); });
+    versionDialog->exec();
+}
+
 void MainWindow::HandleResize(QResizeEvent* event) {
     if (isTableList) {
         m_game_list_frame->RefreshListBackgroundImage();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1281,8 +1281,7 @@ void MainWindow::dropEvent(QDropEvent* event) {
     isExecutable = filePath.endsWith(".exe", Qt::CaseInsensitive);
 #else
     QFileInfo info(filePath);
-    isExecutable = info.isExecutable() || filePath.endsWith(".AppImage", Qt::CaseInsensitive) ||
-                   filePath.endsWith(".appimage", Qt::CaseInsensitive);
+    isExecutable = info.isExecutable() || filePath.endsWith(".AppImage", Qt::CaseInsensitive);
 #endif
 
     if (!isExecutable)

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -5,6 +5,7 @@
 
 #include <QActionGroup>
 #include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QProcess>
 #include <QTranslator>
 
@@ -123,6 +124,8 @@ protected:
             event1->acceptProposedAction();
         }
     }
+
+    void dropEvent(QDropEvent* event) override;
 
     void resizeEvent(QResizeEvent* event) override;
 

--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -183,6 +183,20 @@ VersionDialog::~VersionDialog() {
     delete ui;
 }
 
+void VersionDialog::addExecutableFromDrop(const QString& exePath) {
+    m_pendingExecutablePath = exePath;
+}
+
+void VersionDialog::showEvent(QShowEvent* event) {
+    QDialog::showEvent(event);
+    if (!m_pendingExecutablePath.isEmpty()) {
+        QString path = m_pendingExecutablePath;
+        m_pendingExecutablePath.clear();
+        // Defer one event-loop tick so the dialog is fully painted before the prompt appears
+        QTimer::singleShot(0, this, [this, path]() { AddCustomExecutable(path); });
+    }
+}
+
 void VersionDialog::resizeEvent(QResizeEvent* event) {
     emit WindowResized(event);
     QDialog::resizeEvent(event);

--- a/src/qt_gui/version_dialog.h
+++ b/src/qt_gui/version_dialog.h
@@ -26,6 +26,7 @@ public:
     void checkUpdatePre(const bool showMessage);
     void DownloadListVersion();
     void InstallSelectedVersion();
+    void addExecutableFromDrop(const QString& exePath);
 
 private Q_SLOTS:
     void HandleResize(QResizeEvent* event);
@@ -34,6 +35,7 @@ private:
     Ui::VersionDialog* ui;
     std::shared_ptr<gui_settings> m_gui_settings;
     QNetworkAccessManager* networkManager;
+    QString m_pendingExecutablePath;
 
     void LoadInstalledList();
     QStringList LoadDownloadCache();
@@ -49,6 +51,7 @@ private:
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
+    void showEvent(QShowEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 };


### PR DESCRIPTION
makes it so when an executable is dropped on the main window, the version change box+dialog is opened up


i added this cause it was annoying to open up the version change dialogue everytime i wanted to test a new appimage