### PR TITLE
Pass the game argument to emulator cores before custom arguments instead of after

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1482,7 +1482,7 @@ void MainWindow::StartEmulatorExecutable(std::filesystem::path emuPath, QString 
         }
 
         QStringList game_args{"--game", QString::fromStdWString(last_game_path.wstring())};
-        args.append(game_args);
+        args = game_args + args;
     }
 
     QFileInfo fileInfo(emuPath);


### PR DESCRIPTION
```
./build/shadPS4QtLauncher -d -i -g CUSA00003 -- -- -bootscript=cupcakebootscript.lua
```
Before:
```
[Debug] <Info> (shadps4) main.cpp:125 main: Run: ["/tmp/.mount_ShadpsgKNeHp/usr/bin/shadps4", "--", "-bootscript=cupcakebootscript.lua", "--game", "/media/kalaposfos/Shared/shadps4/games/CUSA00003/eboot.bin"]
[Debug] <Error> (shadps4) main.cpp:178 main: unhandled flags
```
After:
```
[Debug] <Info> (shadps4) main.cpp:125 main: Run: ["/tmp/.mount_ShadpsgKNeHp/usr/bin/shadps4", "--game", "/media/kalaposfos/Shared/shadps4/games/CUSA00003/eboot.bin", "--", "-bootscript=cupcakebootscript.lua"]
(works as intended)
```
