### PR TITLE
[macOS] Add zar file type to info.plist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ set_target_properties(shadPS4QtLauncher PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/dist/MacOSBundleInfo.plist.in"
     MACOSX_BUNDLE_ICON_FILE "shadPS4.icns"
     MACOSX_BUNDLE_SHORT_VERSION_STRING "${APP_VERSION}"
+    MACOSX_BUNDLE_TYPE_EXTENSION "zar"
 )
 
 set_source_files_properties(src/images/shadPS4.icns PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,8 +465,8 @@ set_target_properties(shadPS4QtLauncher PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/dist/MacOSBundleInfo.plist.in"
     MACOSX_BUNDLE_ICON_FILE "shadPS4.icns"
     MACOSX_BUNDLE_SHORT_VERSION_STRING "${APP_VERSION}"
-    MACOSX_BUNDLE_TYPE_EXTENSION "zar"
 )
+set(MACOSX_BUNDLE_TYPE_EXTENSION "zar")
 
 set_source_files_properties(src/images/shadPS4.icns PROPERTIES
     MACOSX_PACKAGE_LOCATION Resources)

--- a/dist/MacOSBundleInfo.plist.in
+++ b/dist/MacOSBundleInfo.plist.in
@@ -25,6 +25,20 @@
 	<string>public.app-category.games</string>
 	<key>GCSupportsGameMode</key>
 	<true/>
+	
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+			<string>${MACOSX_BUNDLE_TYPE_EXTENSION}</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>PlayStation 4 File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 
 	<key>NSHumanReadableCopyright</key>
 	<string></string>


### PR DESCRIPTION
This allows macOS to associate zar files with shadPS4. 

Depends on #408 being merged or else shad won't actually open them.