### PR TITLE
[CI] Bump GitHub actions versions to silence deprecation warnings 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
             ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -162,7 +162,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -231,7 +231,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -292,7 +292,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       env:
           cache-name: ${{ runner.os }}-qt-gcc-cache-cmake-build
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         modules: qtmultimedia
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       env:
           cache-name: ${{ runner.os }}-qt-ninja-cache-cmake-configuration
       with:
@@ -151,7 +151,7 @@ jobs:
         modules: qtmultimedia
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v6 
       env: 
           cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
       with: 
@@ -220,7 +220,7 @@ jobs:
         cache: true
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v6 
       env: 
           cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
       with: 
@@ -281,7 +281,7 @@ jobs:
         cache: true
         
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v6 
       env: 
           cache-name: ${{ runner.os }}-qt-gcc-cache-cmake-configuration
       with: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
             ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -162,7 +162,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -231,7 +231,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2
       env:
           cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
@@ -292,7 +292,7 @@ jobs:
             ${{ env.cache-name }}- 
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2
       env:
           cache-name: ${{ runner.os }}-qt-gcc-cache-cmake-build
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
         Compress-Archive -Path upload/* -DestinationPath shadps4QtLauncher-win64-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}.zip
 
     - name: Upload Windows Qt artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: shadPS4QtLauncher-win64-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: upload/
@@ -184,7 +184,7 @@ jobs:
         macdeployqt upload/shadPS4QtLauncher.app
         codesign --deep -fs - upload/shadPS4QtLauncher.app
         tar cf shadPS4QtLauncher-macos-qt.tar.gz -C upload .
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: shadPS4QtLauncher-macos-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: shadPS4QtLauncher-macos-qt.tar.gz
@@ -250,7 +250,7 @@ jobs:
     - name: Package and Upload Linux Qt artifact
       run: |
         tar cf shadPS4QtLauncher-linux-qt.tar.gz -C ${{github.workspace}}/build shadPS4QtLauncher
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: shadPS4QtLauncher-linux-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: shadPS4QtLauncher-qt.AppImage


### PR DESCRIPTION
Bumps: 

- `cache` to `v6`
- `upload-artifact` to `v7`
- `ccache-action` to `1.2.23` 