### PR TITLE
add context menu item to compress game folders to Zar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,8 @@ set(CORE src/core/file_format/elf.cpp
          src/core/file_format/trp.h
          src/core/file_sys/game_backend.cpp
          src/core/file_sys/game_backend.h
+         src/core/file_sys/zar_packer.cpp
+         src/core/file_sys/zar_packer.h
          src/core/file_sys/backends/host_directory_backend.cpp
          src/core/file_sys/backends/host_directory_backend.h
          src/core/file_sys/backends/zarchive_backend.cpp

--- a/src/core/file_sys/zar_packer.cpp
+++ b/src/core/file_sys/zar_packer.cpp
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadLauncher4 Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <fstream>
+#include <system_error>
+#include <vector>
+
+#include <zarchive/zarchivewriter.h>
+#include "core/file_sys/game_backend.h"
+#include "core/file_sys/zar_packer.h"
+
+namespace Core::FileSys {
+
+struct PackContext {
+    std::filesystem::path output_path;
+    std::ofstream current_output_file;
+    bool has_error = false;
+};
+
+void NewOutputFileCallback(int32_t /*part_index*/, void* ctx) {
+    auto* pack_context = static_cast<PackContext*>(ctx);
+    pack_context->current_output_file.open(pack_context->output_path,
+                                           std::ios::binary | std::ios::trunc);
+    if (!pack_context->current_output_file.is_open()) {
+        pack_context->has_error = true;
+    }
+}
+
+void WriteOutputDataCallback(const void* data, size_t length, void* ctx) {
+    auto* pack_context = static_cast<PackContext*>(ctx);
+    if (!pack_context->current_output_file.is_open()) {
+        pack_context->has_error = true;
+        return;
+    }
+    pack_context->current_output_file.write(static_cast<const char*>(data),
+                                            static_cast<std::streamsize>(length));
+    if (!pack_context->current_output_file.good()) {
+        pack_context->has_error = true;
+    }
+}
+
+bool PackDirectoryToZArchive(const std::filesystem::path& input_dir,
+                             const std::filesystem::path& output_zar,
+                             const std::function<bool(const PackProgress&)>& progress_cb,
+                             std::string* error_message) {
+    namespace fs = std::filesystem;
+
+    const auto fail = [&](const std::string& message) {
+        if (error_message) {
+            *error_message = message;
+        }
+        std::error_code rm_ec;
+        fs::remove(output_zar, rm_ec);
+        return false;
+    };
+
+    std::error_code ec;
+    if (!fs::is_directory(input_dir, ec) || ec) {
+        return fail("Input path is not a directory: " + input_dir.string());
+    }
+
+    PackProgress progress;
+    for (const auto& entry : fs::recursive_directory_iterator(
+             input_dir, fs::directory_options::skip_permission_denied, ec)) {
+        if (ec) {
+            break;
+        }
+        std::error_code entry_ec;
+        if (entry.is_regular_file(entry_ec) && !entry_ec) {
+            const auto size = entry.file_size(entry_ec);
+            if (!entry_ec) {
+                progress.bytes_total += size;
+            }
+        }
+    }
+
+    PackContext pack_context;
+    pack_context.output_path = output_zar;
+
+    std::error_code mkdir_ec;
+    fs::create_directories(output_zar.parent_path(), mkdir_ec);
+
+    ZArchiveWriter writer(NewOutputFileCallback, WriteOutputDataCallback, &pack_context);
+    if (pack_context.has_error) {
+        return fail("Failed to create output file: " + output_zar.string());
+    }
+
+    std::vector<u8> buffer(1 * 1024 * 1024);
+
+    ec.clear();
+    for (const auto& entry : fs::recursive_directory_iterator(
+             input_dir, fs::directory_options::skip_permission_denied, ec)) {
+        if (ec) {
+            return fail("Failed to enumerate input directory: " + ec.message());
+        }
+
+        std::error_code rel_ec;
+        const fs::path rel_path = fs::relative(entry.path(), input_dir, rel_ec);
+        if (rel_ec) {
+            return fail("Failed to resolve relative path for: " + entry.path().string());
+        }
+        const std::string archive_path = rel_path.generic_string();
+
+        std::error_code type_ec;
+        if (entry.is_directory(type_ec) && !type_ec) {
+            if (!writer.MakeDir(archive_path.c_str(), false)) {
+                return fail("Failed to create directory in archive: " + archive_path);
+            }
+            continue;
+        }
+
+        if (!entry.is_regular_file(type_ec) || type_ec) {
+            continue; // skip symlinks/special files, matching upstream ZArchive's packer
+        }
+
+        std::error_code eq_ec;
+        if (fs::equivalent(entry.path(), output_zar, eq_ec) && !eq_ec) {
+            continue; // never try to pack the archive we're currently writing
+        }
+
+        progress.current_file = archive_path;
+        if (progress_cb && !progress_cb(progress)) {
+            return fail("Canceled");
+        }
+
+        if (!writer.StartNewFile(archive_path.c_str())) {
+            return fail("Failed to add file to archive: " + archive_path);
+        }
+
+        std::ifstream in(entry.path(), std::ios::binary);
+        if (!in.is_open()) {
+            return fail("Failed to open input file: " + entry.path().string());
+        }
+
+        while (in) {
+            in.read(reinterpret_cast<char*>(buffer.data()),
+                    static_cast<std::streamsize>(buffer.size()));
+            const auto read_bytes = in.gcount();
+            if (read_bytes <= 0) {
+                break;
+            }
+
+            writer.AppendData(buffer.data(), static_cast<size_t>(read_bytes));
+            if (pack_context.has_error) {
+                return fail("Write error while packing: " + archive_path);
+            }
+
+            progress.bytes_done += static_cast<u64>(read_bytes);
+            if (progress_cb && !progress_cb(progress)) {
+                return fail("Canceled");
+            }
+        }
+
+        if (in.bad()) {
+            return fail("Read error while packing: " + archive_path);
+        }
+    }
+
+    writer.Finalize();
+    pack_context.current_output_file.close();
+
+    if (pack_context.has_error) {
+        return fail("Write error while finalizing archive");
+    }
+
+    return true;
+}
+
+namespace {
+
+void CollectZArchiveEntries(const IGameBackend& backend, const std::string& rel_dir,
+                            std::vector<std::string>& out_files,
+                            std::vector<std::string>& out_dirs) {
+    for (const auto& entry : backend.ListDir(rel_dir)) {
+        const std::string child = rel_dir.empty() ? entry.name : rel_dir + "/" + entry.name;
+        if (entry.is_directory) {
+            out_dirs.push_back(child);
+            CollectZArchiveEntries(backend, child, out_files, out_dirs);
+        } else {
+            out_files.push_back(child);
+        }
+    }
+}
+
+// Reads a single archive entry and writes it out to output_dir/rel_path,
+// creating any missing parent directories. Returns an error string on
+// failure, or an empty string on success.
+std::string ExtractOneFile(const IGameBackend& backend, const std::filesystem::path& output_dir,
+                           const std::string& rel_path) {
+    namespace fs = std::filesystem;
+
+    const auto data = backend.ReadFile(rel_path);
+    if (!data.has_value()) {
+        return "Failed to read file from archive: " + rel_path;
+    }
+
+    const fs::path dest_path = output_dir / fs::path(rel_path);
+    std::error_code dir_ec;
+    fs::create_directories(dest_path.parent_path(), dir_ec);
+
+    std::ofstream out(dest_path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        return "Failed to create output file: " + dest_path.string();
+    }
+    out.write(reinterpret_cast<const char*>(data->data()),
+              static_cast<std::streamsize>(data->size()));
+    if (!out.good()) {
+        return "Write error while extracting: " + rel_path;
+    }
+    out.close();
+    if (!out.good()) {
+        return "Write error while extracting: " + rel_path;
+    }
+    return {};
+}
+
+} // namespace
+
+bool UnpackZArchiveToDirectory(const std::filesystem::path& input_zar,
+                               const std::filesystem::path& output_dir,
+                               const std::function<bool(const UnpackProgress&)>& progress_cb,
+                               std::string* error_message) {
+    namespace fs = std::filesystem;
+
+    const auto fail = [&](const std::string& message) {
+        if (error_message) {
+            *error_message = message;
+        }
+        return false;
+    };
+
+    if (!IsZArchiveFile(input_zar)) {
+        return fail("Input path is not a ZArchive file: " + input_zar.string());
+    }
+
+    const auto backend = OpenGameBackend(input_zar);
+    if (!backend || !backend->IsOpen()) {
+        return fail("Failed to open ZArchive: " + input_zar.string());
+    }
+
+    std::error_code mkdir_ec;
+    fs::create_directories(output_dir, mkdir_ec);
+    if (mkdir_ec) {
+        return fail("Failed to create output directory: " + output_dir.string());
+    }
+
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+    CollectZArchiveEntries(*backend, "", files, dirs);
+
+    for (const auto& rel_dir : dirs) {
+        std::error_code dir_ec;
+        fs::create_directories(output_dir / fs::path(rel_dir), dir_ec);
+        if (dir_ec) {
+            return fail("Failed to create directory: " + rel_dir);
+        }
+    }
+
+    UnpackProgress progress;
+    progress.files_total = files.size();
+
+    for (const auto& rel_path : files) {
+        progress.current_file = rel_path;
+        if (progress_cb && !progress_cb(progress)) {
+            return fail("Canceled");
+        }
+
+        if (const std::string error = ExtractOneFile(*backend, output_dir, rel_path);
+            !error.empty()) {
+            return fail(error);
+        }
+
+        progress.files_done++;
+        if (progress_cb && !progress_cb(progress)) {
+            return fail("Canceled");
+        }
+    }
+
+    return true;
+}
+
+bool ExtractZArchiveFiles(const std::filesystem::path& input_zar,
+                          const std::filesystem::path& output_dir,
+                          const std::vector<std::string>& rel_paths,
+                          const std::function<bool(const UnpackProgress&)>& progress_cb,
+                          std::string* error_message) {
+    namespace fs = std::filesystem;
+
+    const auto fail = [&](const std::string& message) {
+        if (error_message) {
+            *error_message = message;
+        }
+        return false;
+    };
+
+    if (!IsZArchiveFile(input_zar)) {
+        return fail("Input path is not a ZArchive file: " + input_zar.string());
+    }
+    if (rel_paths.empty()) {
+        return fail("No files were selected for extraction.");
+    }
+
+    const auto backend = OpenGameBackend(input_zar);
+    if (!backend || !backend->IsOpen()) {
+        return fail("Failed to open ZArchive: " + input_zar.string());
+    }
+
+    std::error_code mkdir_ec;
+    fs::create_directories(output_dir, mkdir_ec);
+    if (mkdir_ec) {
+        return fail("Failed to create output directory: " + output_dir.string());
+    }
+
+    UnpackProgress progress;
+    progress.files_total = rel_paths.size();
+
+    for (const auto& rel_path : rel_paths) {
+        progress.current_file = rel_path;
+        if (progress_cb && !progress_cb(progress)) {
+            return fail("Canceled");
+        }
+
+        if (const std::string error = ExtractOneFile(*backend, output_dir, rel_path);
+            !error.empty()) {
+            return fail(error);
+        }
+
+        progress.files_done++;
+        if (progress_cb && !progress_cb(progress)) {
+            return fail("Canceled");
+        }
+    }
+
+    return true;
+}
+
+} // namespace Core::FileSys

--- a/src/core/file_sys/zar_packer.h
+++ b/src/core/file_sys/zar_packer.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadLauncher4 Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "common/types.h"
+
+namespace Core::FileSys {
+
+struct PackProgress {
+    u64 bytes_done = 0;
+    u64 bytes_total = 0;
+    std::string current_file;
+};
+
+bool PackDirectoryToZArchive(const std::filesystem::path& input_dir,
+                             const std::filesystem::path& output_zar,
+                             const std::function<bool(const PackProgress&)>& progress_cb,
+                             std::string* error_message);
+
+struct UnpackProgress {
+    u64 files_done = 0;
+    u64 files_total = 0;
+    std::string current_file;
+};
+
+// Extracts every entry of a .zar archive into output_dir (created if needed).
+bool UnpackZArchiveToDirectory(const std::filesystem::path& input_zar,
+                               const std::filesystem::path& output_dir,
+                               const std::function<bool(const UnpackProgress&)>& progress_cb,
+                               std::string* error_message);
+
+// Extracts only the given archive-relative file paths (forward-slash separated,
+// as returned by IGameBackend::ListDir) into output_dir, preserving their
+// relative directory structure.
+bool ExtractZArchiveFiles(const std::filesystem::path& input_zar,
+                          const std::filesystem::path& output_dir,
+                          const std::vector<std::string>& rel_paths,
+                          const std::function<bool(const UnpackProgress&)>& progress_cb,
+                          std::string* error_message);
+
+} // namespace Core::FileSys

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -44,6 +44,9 @@ GameGridFrame::GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
             });
         PopulateGameGrid(m_game_info->m_games, false);
     });
+
+    connect(&m_gui_context_menus, &GuiContextMenus::RequestGameListRefresh, this,
+            &GameGridFrame::RequestRefreshGrid);
 }
 
 void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,

--- a/src/qt_gui/game_grid_frame.h
+++ b/src/qt_gui/game_grid_frame.h
@@ -18,6 +18,7 @@ class GameGridFrame : public QTableWidget {
 
 Q_SIGNALS:
     void GameGridFrameClosed();
+    void RequestRefreshGrid();
 
 public Q_SLOTS:
     void SetGridBackgroundImage(int row, int column);

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -52,9 +52,26 @@ public:
         const std::filesystem::path stem_path = Core::FileSys::StripZArchiveExtension(filePath);
         std::filesystem::path game_update_path = stem_path;
         game_update_path += "-UPDATE";
+        std::filesystem::path zar_update_path = game_update_path;
+        zar_update_path += ".zar";
+
         std::filesystem::path game_patch_path = stem_path;
         game_patch_path += "-patch";
+        std::filesystem::path zar_patch_path = game_patch_path;
+        zar_patch_path += ".zar";
         SceUpdateChecker("param.sfo", param_sfo_path, game_update_path, game_patch_path, game.path);
+
+        if (std::filesystem::exists(game_update_path)) {
+            game.update_path = game_update_path;
+        } else if (std::filesystem::exists(game_patch_path)) {
+            game.update_path = game_patch_path;
+        } else if (std::filesystem::exists(zar_update_path)) {
+            game.update_path = zar_update_path;
+        } else if (std::filesystem::exists(zar_patch_path)) {
+            game.update_path = zar_patch_path;
+        } else {
+            game.update_path = "";
+        }
 
         PSF psf;
         if (psf.Open(param_sfo_path)) {

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -118,6 +118,9 @@ GameListFrame::GameListFrame(std::shared_ptr<gui_settings> gui_settings,
     connect(this->horizontalHeader(), &QHeaderView::customContextMenuRequested, this,
             &GameListFrame::ShowHeaderContextMenu);
 
+    connect(&m_gui_context_menus, &GuiContextMenus::RequestGameListRefresh, this,
+            &GameListFrame::RequestRefreshList);
+
     ToggleColumnVisibility();
 }
 

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -29,6 +29,7 @@ public:
                            std::shared_ptr<IpcClient> ipc_client, QWidget* parent = nullptr);
 Q_SIGNALS:
     void GameListFrameClosed();
+    void RequestRefreshList();
 
 public Q_SLOTS:
     void SetListBackgroundImage(QTableWidgetItem* item);

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -15,6 +15,7 @@
 struct GameInfo {
     std::filesystem::path path;      // root path of game directory
                                      // (normally directory that contains eboot.bin)
+    std::filesystem::path update_path;
     std::filesystem::path icon_path; // path of icon0.png
     std::filesystem::path pic_path;  // path of pic1.png
     std::filesystem::path snd0_path; // path of snd0.at9

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -13,8 +13,8 @@
 #include "core/file_sys/game_backend.h"
 
 struct GameInfo {
-    std::filesystem::path path;      // root path of game directory
-                                     // (normally directory that contains eboot.bin)
+    std::filesystem::path path; // root path of game directory
+                                // (normally directory that contains eboot.bin)
     std::filesystem::path update_path;
     std::filesystem::path icon_path; // path of icon0.png
     std::filesystem::path pic_path;  // path of pic1.png

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -7,8 +7,10 @@
 
 #include <QClipboard>
 #include <QDesktopServices>
+#include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <QTreeWidgetItem>
 
 #include "background_music_player.h"
@@ -22,6 +24,7 @@
 #include "core/emulator_settings.h"
 #include "core/emulator_state.h"
 #include "core/file_sys/game_backend.h"
+#include "core/file_sys/zar_packer.h"
 #include "core/user_settings.h"
 #include "create_shortcut.h"
 #include "create_steam_shortcut.h"
@@ -42,6 +45,9 @@
 
 class GuiContextMenus : public QObject {
     Q_OBJECT
+signals:
+    void RequestGameListRefresh();
+
 public:
     int RequestGameMenu(const QPoint& pos, QVector<GameInfo>& m_games,
                         std::shared_ptr<CompatibilityInfoClass> m_compat_info,
@@ -218,10 +224,200 @@ public:
         viewCompatibilityReport->setEnabled(m_games[itemID].compatibility.status !=
                                             CompatibilityStatus::Unknown);
 
+        QMenu* zarMenu = new QMenu(tr("Zar Compression"), widget);
+        QAction* packGameZar = new QAction(tr("Compress game to zar"), widget);
+        zarMenu->addAction(packGameZar);
+
+        QAction* packUpdateZar = new QAction(tr("Compress update to zar"), widget);
+        if (!m_games[itemID].update_path.empty()) {
+            zarMenu->addAction(packUpdateZar);
+        }
+
+        menu.addMenu(zarMenu);
+
         // Show menu.
         auto selected = menu.exec(global_pos);
         if (!selected) {
             return changedFavorite;
+        }
+
+        auto convertPathToZArchiveHandler = [widget, this](const std::filesystem::path& source_path,
+                                                           const QString& display_name,
+                                                           const QString& dialog_title,
+                                                           const QString& extra_note) {
+            if (Core::FileSys::IsZArchiveFile(source_path)) {
+                QMessageBox::information(widget, dialog_title,
+                                         tr("This is already packed as a ZArchive."));
+                return;
+            }
+
+            std::error_code dir_ec;
+            if (!std::filesystem::is_directory(source_path, dir_ec) || dir_ec) {
+                QMessageBox::critical(widget, dialog_title,
+                                      tr("This folder could not be found on disk."));
+                return;
+            }
+
+            QString default_output;
+            Common::FS::PathToQString(default_output,
+                                      source_path.parent_path() /
+                                          (source_path.filename().string() + ".zar"));
+
+            const QString output_path_str =
+                QFileDialog::getSaveFileName(widget, tr("Convert %1 to ZArchive").arg(display_name),
+                                             default_output, tr("ZArchive Files (*.zar)"));
+            if (output_path_str.isEmpty()) {
+                return;
+            }
+
+            std::filesystem::path output_path = Common::FS::PathFromQString(output_path_str);
+            if (output_path.extension() != ".zar") {
+                output_path += ".zar";
+            }
+
+            std::error_code exists_ec;
+            if (std::filesystem::exists(output_path, exists_ec) && !exists_ec) {
+                const auto overwrite_reply = QMessageBox::question(
+                    widget, dialog_title,
+                    tr("%1 already exists. Overwrite it?")
+                        .arg(QString::fromStdString(output_path.filename().string())),
+                    QMessageBox::Yes | QMessageBox::No);
+                if (overwrite_reply != QMessageBox::Yes) {
+                    return;
+                }
+            }
+
+            // clang-format off
+                QString confirm_message =
+                    tr("This will pack \"%1\" into a single read-only .zar archive. Depending on the "
+                       "size this can take a while, and the archive will temporarily need as "
+                       "much free disk space as the original.\n\n"
+                       "The original folder is left untouched until conversion succeeds, you'll be "
+                       "asked afterward whether to delete it.").arg(display_name);
+                if (!extra_note.isEmpty()) {
+                    confirm_message += extra_note;
+                }
+                confirm_message += tr("\n\nContinue?");
+                const auto confirm_reply = QMessageBox::question(widget, dialog_title, confirm_message,
+                                                                 QMessageBox::Yes | QMessageBox::No);
+            // clang-format on
+            if (confirm_reply != QMessageBox::Yes) {
+                return;
+            }
+
+            auto* progress = new QProgressDialog(dialog_title, tr("Cancel"), 0, 1000, widget);
+            progress->setValue(0);
+            progress->show();
+
+            auto cancel_flag = std::make_shared<std::atomic<bool>>(false);
+            connect(progress, &QProgressDialog::canceled, widget,
+                    [cancel_flag] { *cancel_flag = true; });
+
+            struct ConvertZarResult {
+                bool success = false;
+                std::string error_message;
+            };
+
+            QPointer<QProgressDialog> progress_guard(progress);
+            auto* watcher = new QFutureWatcher<ConvertZarResult>(widget);
+
+            connect(
+                watcher, &QFutureWatcher<ConvertZarResult>::finished, widget,
+                [widget, watcher, progress_guard, source_path, output_path, dialog_title, this]() {
+                    const ConvertZarResult result = watcher->result();
+                    watcher->deleteLater();
+
+                    if (progress_guard) {
+                        progress_guard->close();
+                    }
+
+                    if (!result.success) {
+                        if (result.error_message != "Canceled") {
+                            QMessageBox::critical(
+                                widget, dialog_title,
+                                tr("Failed to convert to ZArchive:\n%1")
+                                    .arg(QString::fromStdString(result.error_message)));
+                        }
+                        return;
+                    }
+
+                    QString source_qpath;
+                    Common::FS::PathToQString(source_qpath, source_path);
+                    const auto delete_reply = QMessageBox::question(
+                        widget, dialog_title,
+                        tr("Conversion finished. Delete the original folder now to free "
+                           "up disk space?\n\n%1")
+                            .arg(source_qpath),
+                        QMessageBox::Yes | QMessageBox::No);
+                    if (delete_reply == QMessageBox::Yes) {
+                        BackgroundMusicPlayer::getInstance().stopMusic();
+
+                        std::error_code remove_ec;
+                        std::filesystem::remove_all(source_path, remove_ec);
+                        if (remove_ec) {
+                            QMessageBox::warning(
+                                widget, dialog_title,
+                                tr("The archive was created, but the original folder could "
+                                   "not be fully deleted. You can remove it manually."));
+                        }
+                    }
+
+                    emit RequestGameListRefresh();
+                });
+
+            auto future = QtConcurrent::run(
+                [source_path, output_path, cancel_flag, progress_guard]() -> ConvertZarResult {
+                    std::string error_message;
+                    const bool ok = Core::FileSys::PackDirectoryToZArchive(
+                        source_path, output_path,
+                        [cancel_flag, progress_guard](const Core::FileSys::PackProgress& p) {
+                            if (progress_guard) {
+                                const int percent =
+                                    p.bytes_total > 0
+                                        ? static_cast<int>((p.bytes_done * 1000) / p.bytes_total)
+                                        : 0;
+                                QMetaObject::invokeMethod(
+                                    progress_guard.data(),
+                                    [progress_guard, percent, file = p.current_file]() {
+                                        if (!progress_guard) {
+                                            return;
+                                        }
+                                        progress_guard->setValue(percent);
+                                        progress_guard->setLabelText(
+                                            tr("Packing: %1").arg(QString::fromStdString(file)));
+                                    },
+                                    Qt::QueuedConnection);
+                            }
+                            return !cancel_flag->load();
+                        },
+                        &error_message);
+
+                    return ConvertZarResult{ok, ok ? std::string() : error_message};
+                });
+
+            watcher->setFuture(future);
+        };
+
+        if (selected == packGameZar) {
+            QString extra_note = "";
+            if (!m_games[itemID].update_path.empty() &&
+                !Core::FileSys::IsZArchiveFile(m_games[itemID].update_path)) {
+                extra_note =
+                    tr("\n\nThis game has a separate update/patch folder. Only the base game "
+                       "will be archived; the update/patch folder will not be included and "
+                       "will be left as-is. Use \"Convert Update to ZArchive\" separately if "
+                       "you'd like to archive it too.");
+            }
+
+            convertPathToZArchiveHandler(m_games[itemID].path,
+                                         QString::fromStdString(m_games[itemID].name),
+                                         tr("Convert to ZArchive"), extra_note);
+        }
+
+        if (selected == packUpdateZar) {
+            convertPathToZArchiveHandler(m_games[itemID].update_path,
+                                         QString::fromStdString(m_games[itemID].name),
+                                         tr("Convert to ZArchive"), "");
         }
 
         if (selected == launchNormally) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -373,6 +373,8 @@ void MainWindow::CreateDockWindows(bool newDock) {
         slider_pos = m_gui_settings->GetValue(gui::gl_slider_pos).toInt();
         ui->sizeSlider->setSliderPosition(slider_pos); // set slider pos at start;
         isTableList = true;
+        connect(m_game_list_frame.data(), &GameListFrame::RequestRefreshList, this,
+                &MainWindow::RefreshGameTable);
     } else if (table_mode == 1) { // Grid
         m_game_list_frame->hide();
         m_elf_viewer->hide();
@@ -387,6 +389,8 @@ void MainWindow::CreateDockWindows(bool newDock) {
         slider_pos = m_gui_settings->GetValue(gui::gg_slider_pos).toInt();
         ui->sizeSlider->setSliderPosition(slider_pos); // set slider pos at start;
         isTableList = false;
+        connect(m_game_grid_frame.data(), &GameGridFrame::RequestRefreshGrid, this,
+                &MainWindow::RefreshGameTable);
     } else {
         m_game_list_frame->hide();
         m_game_grid_frame->hide();


### PR DESCRIPTION
ports the zar packer from shadlaucher4 to be usable in qtlauncher with the context menu

<img width="365" height="101" alt="image" src="https://github.com/user-attachments/assets/9c7f5a4b-67d8-4999-8256-8db8b8891998" />
