### PR TITLE
Allow to Select and Remove Multiple Versions at Once

### DIFF
--- a/src/qt_gui/version_dialog.cpp
+++ b/src/qt_gui/version_dialog.cpp
@@ -103,70 +103,82 @@ VersionDialog::VersionDialog(std::shared_ptr<gui_settings> gui_settings, QWidget
     });
 
     connect(ui->deleteVersionButton, &QPushButton::clicked, this, [this]() {
-        QTreeWidgetItem* selectedItem = ui->installedTreeWidget->currentItem();
-        if (!selectedItem) {
+        QList<QTreeWidgetItem*> selectedItems = ui->installedTreeWidget->selectedItems();
+        if (selectedItems.isEmpty()) {
             QMessageBox::warning(
                 this, tr("Error"),
                 tr("No version selected. Please choose one from the list to delete."));
             return;
         }
 
-        QString versionName = selectedItem->text(1);
-        QString fullPath = selectedItem->text(4);
-
-        if (fullPath.isEmpty()) {
-            QMessageBox::critical(this, tr("Error"), tr("Failed to determine the folder path."));
-            return;
+        // If multiple versions are selected, show all of them in the confirmation
+        QStringList versionNames;
+        for (QTreeWidgetItem* item : selectedItems) {
+            versionNames << item->text(1);
         }
         auto reply = QMessageBox::question(this, tr("Delete version"),
                                            tr("Do you want to delete the version") +
-                                               QString(" \"%1\" ?").arg(versionName),
+                                               QString(":\n\n%1\n").arg(versionNames.join("\n")),
                                            QMessageBox::Yes | QMessageBox::No);
         if (reply == QMessageBox::No)
             return;
 
-        // Check if it is of type Local (type == 2)
-        auto versions = VersionManager::GetVersionList({});
-        int versionType = 2;
-        for (const auto& v : versions) {
-            if (v.name == versionName.toStdString()) {
-                versionType = static_cast<int>(v.type);
-                break;
-            }
-        }
+        for (QTreeWidgetItem* selectedItem : selectedItems) {
+            QString versionName = selectedItem->text(1);
+            QString fullPath = selectedItem->text(4);
 
-        if (versionType == 2) {
-            VersionManager::RemoveVersion(versionName.toStdString());
-            LoadInstalledList();
-            return;
-        }
-
-        QFileInfo info(fullPath);
-        QString folderPath;
-        if (info.exists() && info.isDir()) {
-            folderPath = info.absoluteFilePath();
-        } else {
-            folderPath = info.absolutePath();
-        }
-
-        if (folderPath.isEmpty()) {
-            QMessageBox::critical(this, tr("Error"),
-                                  tr("Failed to determine the folder to remove.") +
-                                      QString("\n \"%1\"").arg(fullPath));
-            return;
-        }
-
-        QDir dirToRemove(folderPath);
-        if (dirToRemove.exists()) {
-            if (!dirToRemove.removeRecursively()) {
+            if (fullPath.isEmpty()) {
                 QMessageBox::critical(this, tr("Error"),
-                                      tr("Failed to delete folder.") +
-                                          QString("\n \"%1\"").arg(folderPath));
+                                      tr("Failed to determine the folder path."));
                 return;
             }
+
+            // Check if it is of type Local (type == 2)
+            auto versions = VersionManager::GetVersionList({});
+            int versionType = 2;
+
+            for (const auto& v : versions) {
+                if (v.name == versionName.toStdString()) {
+                    versionType = static_cast<int>(v.type);
+                    break;
+                }
+            }
+
+            if (versionType == 2) {
+                VersionManager::RemoveVersion(versionName.toStdString());
+                continue;
+            }
+
+            QFileInfo info(fullPath);
+            QString folderPath;
+
+            if (info.exists() && info.isDir()) {
+                folderPath = info.absoluteFilePath();
+            } else {
+                folderPath = info.absolutePath();
+            }
+
+            if (folderPath.isEmpty()) {
+                QMessageBox::critical(this, tr("Error"),
+                                      tr("Failed to determine the folder to remove.") +
+                                          QString("\n \"%1\"").arg(fullPath));
+                return;
+            }
+
+            QDir dirToRemove(folderPath);
+
+            if (dirToRemove.exists()) {
+                if (!dirToRemove.removeRecursively()) {
+                    QMessageBox::critical(this, tr("Error"),
+                                          tr("Failed to delete folder.") +
+                                              QString("\n \"%1\"").arg(folderPath));
+                    return;
+                }
+            }
+
+            VersionManager::RemoveVersion(versionName.toStdString());
         }
 
-        VersionManager::RemoveVersion(versionName.toStdString());
         LoadInstalledList();
     });
 

--- a/src/qt_gui/version_dialog.ui
+++ b/src/qt_gui/version_dialog.ui
@@ -120,6 +120,9 @@
          </item>
          <item>
           <widget class="QTreeWidget" name="installedTreeWidget">
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+           </property>
            <column>
             <property name="text">
              <string>Selected</string>


### PR DESCRIPTION
Closes https://github.com/shadps4-emu/shadps4-qtlauncher/issues/433

It is now possible to delete multiple versions at once by selecting them from the list using Ctrl or Shift.

<img width="488" height="368" alt="image" src="https://github.com/user-attachments/assets/1a6b154c-7a30-4d5c-9d3e-2be276c01408" />
