### PR TITLE
Add custom background image option (List/Grid view)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/control_settings.cpp
            src/qt_gui/control_settings.h
            src/qt_gui/control_settings.ui
+           src/qt_gui/custom_background_provider.cpp
+           src/qt_gui/custom_background_provider.h
            src/qt_gui/kbm_gui.cpp	   
            src/qt_gui/kbm_gui.h
            src/qt_gui/kbm_gui.ui

--- a/src/qt_gui/custom_background_provider.cpp
+++ b/src/qt_gui/custom_background_provider.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "custom_background_provider.h"
+
+CustomBackgroundProvider::CustomBackgroundProvider(QObject* parent) : QObject(parent) {}
+
+bool CustomBackgroundProvider::SetImagePath(const QString& path) {
+    Clear();
+
+    if (path.isEmpty()) {
+        return true;
+    }
+
+    if (path.endsWith(QStringLiteral(".gif"), Qt::CaseInsensitive)) {
+        auto* movie = new QMovie(path);
+        movie->jumpToFrame(0);
+        if (!movie->isValid() || movie->currentImage().isNull()) {
+            delete movie;
+            return false;
+        }
+
+        m_movie.reset(movie);
+        m_isAnimated = true;
+        connect(m_movie.data(), &QMovie::frameChanged, this,
+                [this](int) { emit FrameChanged(); });
+        m_movie->start();
+    } else {
+        QImage image(path);
+        if (image.isNull()) {
+            return false;
+        }
+
+        m_staticImage = image;
+        m_isAnimated = false;
+    }
+
+    m_path = path;
+    emit FrameChanged();
+    return true;
+}
+
+void CustomBackgroundProvider::Clear() {
+    if (m_movie) {
+        m_movie->stop();
+        m_movie.reset();
+    }
+    m_staticImage = QImage();
+    m_isAnimated = false;
+    if (!m_path.isEmpty()) {
+        m_path.clear();
+        emit FrameChanged();
+    }
+}
+
+bool CustomBackgroundProvider::IsSet() const {
+    return !m_path.isEmpty();
+}
+
+QImage CustomBackgroundProvider::CurrentFrame() const {
+    if (m_isAnimated) {
+        return m_movie ? m_movie->currentImage() : QImage();
+    }
+    return m_staticImage;
+}

--- a/src/qt_gui/custom_background_provider.h
+++ b/src/qt_gui/custom_background_provider.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QImage>
+#include <QMovie>
+#include <QObject>
+#include <QScopedPointer>
+#include <QString>
+
+// Holds the user-selected custom background image (a static image or an
+// animated GIF) shown in the game list/grid whenever no game is currently
+// selected. Shared by GameListFrame and GameGridFrame so both views stay in
+// sync and only decode/animate the image once.
+class CustomBackgroundProvider : public QObject {
+    Q_OBJECT
+
+public:
+    static CustomBackgroundProvider& getInstance() {
+        static CustomBackgroundProvider instance;
+        return instance;
+    }
+
+    // Loads the image (or animated GIF, detected by its .gif extension) at
+    // `path`. Returns false if the file could not be loaded, in which case
+    // any previously configured image is left cleared. Passing an empty path
+    // is equivalent to calling Clear().
+    bool SetImagePath(const QString& path);
+    void Clear();
+
+    bool IsSet() const;
+    QString ImagePath() const {
+        return m_path;
+    }
+    // Returns the frame that should currently be drawn: the static image, or
+    // the animated GIF's current frame.
+    QImage CurrentFrame() const;
+
+Q_SIGNALS:
+    // Emitted whenever the frame that CurrentFrame() would return changes:
+    // a new image was set, the image was cleared, or the animated GIF
+    // advanced to its next frame.
+    void FrameChanged();
+
+private:
+    explicit CustomBackgroundProvider(QObject* parent = nullptr);
+    CustomBackgroundProvider(const CustomBackgroundProvider&) = delete;
+    CustomBackgroundProvider& operator=(const CustomBackgroundProvider&) = delete;
+
+    QString m_path;
+    QImage m_staticImage;
+    QScopedPointer<QMovie> m_movie;
+    bool m_isAnimated = false;
+};

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/path_util.h"
+#include "custom_background_provider.h"
 #include "game_grid_frame.h"
 #include "main_window.h"
 #include "qt_gui/compatibility_info.h"
@@ -27,6 +28,10 @@ GameGridFrame::GameGridFrame(std::shared_ptr<gui_settings> gui_settings,
     this->verticalHeader()->setVisible(false);
     this->setContextMenuPolicy(Qt::CustomContextMenu);
     PopulateGameGrid(m_game_info->m_games, false);
+    RefreshGridBackgroundImage();
+
+    connect(&CustomBackgroundProvider::getInstance(), &CustomBackgroundProvider::FrameChanged,
+            this, &GameGridFrame::RefreshGridBackgroundImage);
 
     connect(this, &QTableWidget::currentCellChanged, this, &GameGridFrame::onCurrentCellChanged);
 
@@ -56,6 +61,7 @@ void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
         cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
+        RefreshGridBackgroundImage();
         return;
     }
 
@@ -68,6 +74,7 @@ void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
         cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
+        RefreshGridBackgroundImage();
         return;
     }
 
@@ -76,6 +83,7 @@ void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
         cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
+        RefreshGridBackgroundImage();
         return;
     }
 
@@ -221,11 +229,20 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
 
 void GameGridFrame::RefreshGridBackgroundImage() {
     QPalette palette;
-    if (!backgroundImage.isNull() &&
-        m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
+    QImage imageToShow;
+
+    if (!validCellSelected && CustomBackgroundProvider::getInstance().IsSet()) {
+        // No game selected: show the user's custom background image instead.
+        imageToShow = CustomBackgroundProvider::getInstance().CurrentFrame();
+    } else if (!backgroundImage.isNull() &&
+               m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
+        imageToShow = backgroundImage;
+    }
+
+    if (!imageToShow.isNull()) {
         QSize widgetSize = size();
         QPixmap scaledPixmap =
-            QPixmap::fromImage(backgroundImage)
+            QPixmap::fromImage(imageToShow)
                 .scaled(widgetSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
         int x = (widgetSize.width() - scaledPixmap.width()) / 2;
         int y = (widgetSize.height() - scaledPixmap.height()) / 2;

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include "common/path_util.h"
 #include "custom_background_provider.h"
 #include "game_grid_frame.h"
@@ -230,10 +231,12 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
 void GameGridFrame::RefreshGridBackgroundImage() {
     QPalette palette;
     QImage imageToShow;
+    bool isCustomBackground = false;
 
     if (!validCellSelected && CustomBackgroundProvider::getInstance().IsSet()) {
         // No game selected: show the user's custom background image instead.
         imageToShow = CustomBackgroundProvider::getInstance().CurrentFrame();
+        isCustomBackground = true;
     } else if (!backgroundImage.isNull() &&
                m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
         imageToShow = backgroundImage;
@@ -249,6 +252,11 @@ void GameGridFrame::RefreshGridBackgroundImage() {
         QPixmap finalPixmap(widgetSize);
         finalPixmap.fill(Qt::transparent);
         QPainter painter(&finalPixmap);
+        if (isCustomBackground) {
+            const int opacity =
+                m_gui_settings->GetValue(gui::gl_customBackgroundImageOpacity).toInt();
+            painter.setOpacity(std::clamp(opacity, 0, 100) / 100.0);
+        }
         painter.drawPixmap(x, y, scaledPixmap);
         palette.setBrush(QPalette::Base, QBrush(finalPixmap));
     }

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -4,6 +4,7 @@
 #include <QToolTip>
 #include "common/logging/log.h"
 #include "common/path_util.h"
+#include "custom_background_provider.h"
 #include "game_list_frame.h"
 #include "game_list_utils.h"
 #include "main_window.h"
@@ -56,6 +57,10 @@ GameListFrame::GameListFrame(std::shared_ptr<gui_settings> gui_settings,
     this->horizontalHeader()->setSectionResizeMode(11, QHeaderView::Stretch);
     this->setColumnHidden(11, true);
     PopulateGameList();
+    RefreshListBackgroundImage();
+
+    connect(&CustomBackgroundProvider::getInstance(), &CustomBackgroundProvider::FrameChanged,
+            this, &GameListFrame::RefreshListBackgroundImage);
 
     connect(this, &QTableWidget::currentCellChanged, this, &GameListFrame::onCurrentCellChanged);
     connect(this->verticalScrollBar(), &QScrollBar::valueChanged, this,
@@ -128,9 +133,13 @@ void GameListFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
                                          int previousColumn) {
     QTableWidgetItem* item = this->item(currentRow, currentColumn);
     if (!item) {
+        // No game selected: fall back to the custom background image, if any.
+        m_hasSelection = false;
+        RefreshListBackgroundImage();
         return;
     }
     m_current_item = item; // Store current item
+    m_hasSelection = true;
     SetListBackgroundImage(item);
     PlayBackgroundMusic(item);
 }
@@ -245,11 +254,20 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
 
 void GameListFrame::RefreshListBackgroundImage() {
     QPalette palette;
-    if (!backgroundImage.isNull() &&
-        m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
+    QImage imageToShow;
+
+    if (!m_hasSelection && CustomBackgroundProvider::getInstance().IsSet()) {
+        // No game selected: show the user's custom background image instead.
+        imageToShow = CustomBackgroundProvider::getInstance().CurrentFrame();
+    } else if (!backgroundImage.isNull() &&
+               m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
+        imageToShow = backgroundImage;
+    }
+
+    if (!imageToShow.isNull()) {
         QSize widgetSize = size();
         QPixmap scaledPixmap =
-            QPixmap::fromImage(backgroundImage)
+            QPixmap::fromImage(imageToShow)
                 .scaled(widgetSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
         int x = (widgetSize.width() - scaledPixmap.width()) / 2;
         int y = (widgetSize.height() - scaledPixmap.height()) / 2;

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <QToolTip>
+#include <algorithm>
 #include "common/logging/log.h"
 #include "common/path_util.h"
 #include "custom_background_provider.h"
@@ -255,10 +256,12 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
 void GameListFrame::RefreshListBackgroundImage() {
     QPalette palette;
     QImage imageToShow;
+    bool isCustomBackground = false;
 
     if (!m_hasSelection && CustomBackgroundProvider::getInstance().IsSet()) {
         // No game selected: show the user's custom background image instead.
         imageToShow = CustomBackgroundProvider::getInstance().CurrentFrame();
+        isCustomBackground = true;
     } else if (!backgroundImage.isNull() &&
                m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool()) {
         imageToShow = backgroundImage;
@@ -274,6 +277,11 @@ void GameListFrame::RefreshListBackgroundImage() {
         QPixmap finalPixmap(widgetSize);
         finalPixmap.fill(Qt::transparent);
         QPainter painter(&finalPixmap);
+        if (isCustomBackground) {
+            const int opacity =
+                m_gui_settings->GetValue(gui::gl_customBackgroundImageOpacity).toInt();
+            painter.setOpacity(std::clamp(opacity, 0, 100) / 100.0);
+        }
         painter.drawPixmap(x, y, scaledPixmap);
         palette.setBrush(QPalette::Base, QBrush(finalPixmap));
     }

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -54,6 +54,7 @@ private:
     QTableWidgetItem* m_current_item = nullptr;
     int m_last_opacity = -1; // Track last opacity to avoid unnecessary recomputation
     std::filesystem::path m_current_game_path; // Track current game path to detect changes
+    bool m_hasSelection = false; // Whether a game is currently selected
     std::shared_ptr<gui_settings> m_gui_settings;
 
 public:

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -46,6 +46,10 @@ const gui_value gl_backgroundImageOpacity = gui_value(game_list, "backgroundImag
 const gui_value gl_playBackgroundMusic = gui_value(game_list, "playBackgroundMusic", true);
 const gui_value gl_backgroundMusicVolume = gui_value(game_list, "backgroundMusicVolume", 50);
 const gui_value gl_VolumeSlider = gui_value(game_list, "volumeSlider", 100);
+// Path to a user-selected custom background image (static or GIF) shown
+// when no game is selected. Empty means no custom background is set.
+const gui_value gl_customBackgroundImagePath =
+    gui_value(game_list, "customBackgroundImagePath", "");
 
 // game list (column)
 const gui_value glc_showIconEnabled = gui_value(game_list_column, "showIcon", true);

--- a/src/qt_gui/gui_settings.h
+++ b/src/qt_gui/gui_settings.h
@@ -46,6 +46,9 @@ const gui_value gl_backgroundImageOpacity = gui_value(game_list, "backgroundImag
 const gui_value gl_playBackgroundMusic = gui_value(game_list, "playBackgroundMusic", true);
 const gui_value gl_backgroundMusicVolume = gui_value(game_list, "backgroundMusicVolume", 50);
 const gui_value gl_VolumeSlider = gui_value(game_list, "volumeSlider", 100);
+// Opacity (0-100) applied to the custom background image/GIF set from the View menu.
+const gui_value gl_customBackgroundImageOpacity =
+    gui_value(game_list, "customBackgroundImageOpacity", 100);
 // Path to a user-selected custom background image (static or GIF) shown
 // when no game is selected. Empty means no custom background is set.
 const gui_value gl_customBackgroundImagePath =

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -21,6 +21,7 @@
 #include "core/emulator_state.h"
 #include "core/file_sys/game_backend.h"
 #include "crypto_key_dialog.h"
+#include "custom_background_provider.h"
 #include "dimensions_dialog.h"
 #include "game_install_dialog.h"
 #include "hotkeys.h"
@@ -469,6 +470,10 @@ void MainWindow::CreateConnects() {
     connect(ui->showGameListAct, &QAction::triggered, this, &MainWindow::ShowGameList);
     connect(ui->toggleLabelsAct, &QAction::toggled, this, &MainWindow::toggleLabelsUnderIcons);
     connect(ui->fullscreenButton, &QPushButton::clicked, this, &MainWindow::toggleFullscreen);
+    connect(ui->setCustomBackgroundImageAct, &QAction::triggered, this,
+            &MainWindow::SetCustomBackgroundImage);
+    connect(ui->clearCustomBackgroundImageAct, &QAction::triggered, this,
+            &MainWindow::ClearCustomBackgroundImage);
 
     connect(ui->showLogAct, &QAction::triggered, this, [this](bool state) {
         if (state) {
@@ -1113,6 +1118,46 @@ void MainWindow::ConfigureGuiFromSettings() {
 
     BackgroundMusicPlayer::getInstance().setVolume(
         m_gui_settings->GetValue(gui::gl_backgroundMusicVolume).toInt());
+
+    const QString customBackgroundPath =
+        m_gui_settings->GetValue(gui::gl_customBackgroundImagePath).toString();
+    if (!customBackgroundPath.isEmpty() &&
+        !CustomBackgroundProvider::getInstance().SetImagePath(customBackgroundPath)) {
+        // The stored image can no longer be loaded (e.g. it was moved or
+        // deleted); forget it instead of silently failing on every startup.
+        m_gui_settings->SetValue(gui::gl_customBackgroundImagePath, QString(""));
+    }
+    ui->clearCustomBackgroundImageAct->setEnabled(CustomBackgroundProvider::getInstance().IsSet());
+}
+
+void MainWindow::SetCustomBackgroundImage() {
+    QFileDialog dialog;
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    dialog.setNameFilter(tr("Image Files (*.png *.jpg *.jpeg *.bmp *.gif)"));
+    if (!dialog.exec()) {
+        return;
+    }
+
+    const QStringList fileNames = dialog.selectedFiles();
+    if (fileNames.isEmpty()) {
+        return;
+    }
+
+    const QString path = fileNames.first();
+    if (!CustomBackgroundProvider::getInstance().SetImagePath(path)) {
+        QMessageBox::critical(this, tr("Custom Background Image"),
+                              tr("Could not load the selected image."));
+        return;
+    }
+
+    m_gui_settings->SetValue(gui::gl_customBackgroundImagePath, path);
+    ui->clearCustomBackgroundImageAct->setEnabled(true);
+}
+
+void MainWindow::ClearCustomBackgroundImage() {
+    CustomBackgroundProvider::getInstance().Clear();
+    m_gui_settings->SetValue(gui::gl_customBackgroundImagePath, QString(""));
+    ui->clearCustomBackgroundImageAct->setEnabled(false);
 }
 
 void MainWindow::SaveWindowState() {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -547,6 +547,18 @@ void MainWindow::CreateConnects() {
                     }
                 });
 
+        connect(settingsDialog, &SettingsDialog::CustomBackgroundOpacityChanged, this,
+                [this](int opacity) {
+                    m_gui_settings->SetValue(gui::gl_customBackgroundImageOpacity,
+                                             std::clamp(opacity, 0, 100));
+                    if (m_game_list_frame) {
+                        m_game_list_frame->RefreshListBackgroundImage();
+                    }
+                    if (m_game_grid_frame) {
+                        m_game_grid_frame->RefreshGridBackgroundImage();
+                    }
+                });
+
         settingsDialog->exec();
     });
 
@@ -579,6 +591,18 @@ void MainWindow::CreateConnects() {
                             m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
                                                                       m_game_grid_frame->crtColumn);
                         }
+                    }
+                });
+
+        connect(settingsDialog, &SettingsDialog::CustomBackgroundOpacityChanged, this,
+                [this](int opacity) {
+                    m_gui_settings->SetValue(gui::gl_customBackgroundImageOpacity,
+                                             std::clamp(opacity, 0, 100));
+                    if (m_game_list_frame) {
+                        m_game_list_frame->RefreshListBackgroundImage();
+                    }
+                    if (m_game_grid_frame) {
+                        m_game_grid_frame->RefreshGridBackgroundImage();
                     }
                 });
 

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -54,6 +54,8 @@ private Q_SLOTS:
     void HandleResize(QResizeEvent* event);
     void OnLanguageChanged(const QString& locale);
     void toggleLabelsUnderIcons();
+    void SetCustomBackgroundImage();
+    void ClearCustomBackgroundImage();
 
 private:
     Ui_MainWindow* ui;

--- a/src/qt_gui/main_window_themes.cpp
+++ b/src/qt_gui/main_window_themes.cpp
@@ -191,7 +191,16 @@ void WindowThemes::SetWindowTheme(Theme theme, QLineEdit* mw_searchbar) {
                             "border-radius: 4px; padding: 5px; }"
 
                             "QCheckBox::indicator:unchecked {"
-                            "border: 1px solid #808080; border-radius: 4px; }");
+                            "border: 1px solid #808080; border-radius: 4px; }"
+
+                            // Once a stylesheet is set anywhere in the app, Qt's CSS
+                            // style engine takes over background painting for every
+                            // widget and ignores ad-hoc setPalette() calls, including
+                            // the per-game and custom background images drawn onto
+                            // these two widgets. Explicitly deferring to the current
+                            // palette's Base brush here restores that behavior.
+                            "GameListFrame, GameGridFrame {"
+                            "background: palette(base); }");
         break;
     }
 }

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -25,6 +25,8 @@ public:
     QAction* setIconSizeMediumAct;
     QAction* setIconSizeLargeAct;
     QAction* toggleLabelsAct;
+    QAction* setCustomBackgroundImageAct;
+    QAction* clearCustomBackgroundImageAct;
     QAction* setlistModeListAct;
     QAction* setlistModeGridAct;
     QAction* setlistElfAct;
@@ -122,6 +124,13 @@ public:
 
         toggleLabelsAct = new QAction(MainWindow);
         toggleLabelsAct->setObjectName("toggleLabelsAct");
+
+        setCustomBackgroundImageAct = new QAction(MainWindow);
+        setCustomBackgroundImageAct->setObjectName("setCustomBackgroundImageAct");
+
+        clearCustomBackgroundImageAct = new QAction(MainWindow);
+        clearCustomBackgroundImageAct->setObjectName("clearCustomBackgroundImageAct");
+        clearCustomBackgroundImageAct->setEnabled(false);
         toggleLabelsAct->setCheckable(true);
 
         setIconSizeTinyAct = new QAction(MainWindow);
@@ -347,6 +356,9 @@ public:
         menuView->addAction(menuGame_List_Mode->menuAction());
         menuView->addAction(menuGame_List_Icons->menuAction());
         menuView->addAction(toggleLabelsAct);
+        menuView->addSeparator();
+        menuView->addAction(setCustomBackgroundImageAct);
+        menuView->addAction(clearCustomBackgroundImageAct);
         menuView->addAction(menuThemes->menuAction());
         menuThemes->addAction(setThemeDark);
         menuThemes->addAction(setThemeLight);
@@ -470,6 +482,10 @@ public:
         toolBar->setWindowTitle(QCoreApplication::translate("MainWindow", "toolBar", nullptr));
         toggleLabelsAct->setText(
             QCoreApplication::translate("MainWindow", "Show Labels Under Icons"));
+        setCustomBackgroundImageAct->setText(
+            QCoreApplication::translate("MainWindow", "Set Custom Background Image...", nullptr));
+        clearCustomBackgroundImageAct->setText(QCoreApplication::translate(
+            "MainWindow", "Clear Custom Background Image", nullptr));
     } // retranslateUi
 };
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -80,6 +80,7 @@ QMap<QString, QString> micMap;
 QMap<int, QString> audioBackendMap;
 
 int backgroundImageOpacitySlider_backup;
+int customBackgroundImageOpacitySlider_backup;
 int bgm_volume_backup;
 
 static std::vector<QString> m_physical_devices;
@@ -274,6 +275,9 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         } else if (button == ui->buttonBox->button(QDialogButtonBox::Close)) {
             ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
             emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+            ui->customBackgroundImageOpacitySlider->setValue(
+                customBackgroundImageOpacitySlider_backup);
+            emit CustomBackgroundOpacityChanged(customBackgroundImageOpacitySlider_backup);
             ui->BGMVolumeSlider->setValue(bgm_volume_backup);
             BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
             SyncRealTimeWidgetstoConfig();
@@ -339,6 +343,9 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     {
         connect(ui->backgroundImageOpacitySlider, &QSlider::valueChanged, this,
                 [this](int value) { emit BackgroundOpacityChanged(value); });
+
+        connect(ui->customBackgroundImageOpacitySlider, &QSlider::valueChanged, this,
+                [this](int value) { emit CustomBackgroundOpacityChanged(value); });
 
         connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
                 [](int value) { BackgroundMusicPlayer::getInstance().setVolume(value); });
@@ -535,6 +542,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
 
         // GUI
         ui->GUIBackgroundImageGroupBox->installEventFilter(this);
+        ui->GUICustomBackgroundImageGroupBox->installEventFilter(this);
         ui->GUIMusicGroupBox->installEventFilter(this);
         ui->enableCompatibilityCheckBox->installEventFilter(this);
         ui->checkCompatibilityOnStartupCheckBox->installEventFilter(this);
@@ -622,6 +630,8 @@ void SettingsDialog::closeEvent(QCloseEvent* event) {
     if (!is_game_saving) {
         ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
         emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+        ui->customBackgroundImageOpacitySlider->setValue(customBackgroundImageOpacitySlider_backup);
+        emit CustomBackgroundOpacityChanged(customBackgroundImageOpacitySlider_backup);
         ui->BGMVolumeSlider->setValue(bgm_volume_backup);
         BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
         SyncRealTimeWidgetstoConfig();
@@ -693,9 +703,13 @@ void SettingsDialog::LoadValuesFromConfig() {
             m_gui_settings->GetValue(gui::gl_backgroundImageOpacity).toInt());
         ui->showBackgroundImageCheckBox->setChecked(
             m_gui_settings->GetValue(gui::gl_showBackgroundImage).toBool());
+        ui->customBackgroundImageOpacitySlider->setValue(
+            m_gui_settings->GetValue(gui::gl_customBackgroundImageOpacity).toInt());
 
         backgroundImageOpacitySlider_backup =
             m_gui_settings->GetValue(gui::gl_backgroundImageOpacity).toInt();
+        customBackgroundImageOpacitySlider_backup =
+            m_gui_settings->GetValue(gui::gl_customBackgroundImageOpacity).toInt();
         bgm_volume_backup = m_gui_settings->GetValue(gui::gl_backgroundMusicVolume).toInt();
 
 #ifdef ENABLE_UPDATER
@@ -934,6 +948,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
 #endif
     } else if (elementName == "GUIBackgroundImageGroupBox") {
         text = tr("Background Image:\\nControl the opacity of the game background image.");
+    } else if (elementName == "GUICustomBackgroundImageGroupBox") {
+        text = tr("Custom Background Image:\\nControl the opacity of the custom background image or GIF set from the View menu.");
     } else if (elementName == "GUIMusicGroupBox") {
         text = tr("Play Title Music:\\nIf a game supports it, enable playing special music when selecting the game in the GUI.");
     } else if (elementName == "enableHDRCheckBox") {
@@ -1249,6 +1265,10 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
         m_gui_settings->SetValue(gui::gl_backgroundImageOpacity,
                                  std::clamp(ui->backgroundImageOpacitySlider->value(), 0, 100));
         emit BackgroundOpacityChanged(ui->backgroundImageOpacitySlider->value());
+        m_gui_settings->SetValue(
+            gui::gl_customBackgroundImageOpacity,
+            std::clamp(ui->customBackgroundImageOpacitySlider->value(), 0, 100));
+        emit CustomBackgroundOpacityChanged(ui->customBackgroundImageOpacitySlider->value());
         m_gui_settings->SetValue(gui::gen_homeTab,
                                  chooseHomeTabMap.value(ui->chooseHomeTabComboBox->currentText()));
     }
@@ -1298,6 +1318,7 @@ void SettingsDialog::SetDefaultValues() {
     if (!is_game_specific) {
         m_gui_settings->SetValue(gui::gl_showBackgroundImage, true);
         m_gui_settings->SetValue(gui::gl_backgroundImageOpacity, 50);
+        m_gui_settings->SetValue(gui::gl_customBackgroundImageOpacity, 100);
         m_gui_settings->SetValue(gui::gl_playBackgroundMusic, false);
         m_gui_settings->SetValue(gui::gl_backgroundMusicVolume, 50);
         m_gui_settings->SetValue(gui::gen_checkForUpdates, false);

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -38,6 +38,7 @@ signals:
     void LanguageChanged(const QString& locale);
     void CompatibilityChanged();
     void BackgroundOpacityChanged(int opacity);
+    void CustomBackgroundOpacityChanged(int opacity);
 
 private:
     void LoadValuesFromConfig();

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -505,6 +505,63 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="GUICustomBackgroundImageGroupBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Custom Background Image</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="customBackgroundImageVLayout">
+                  <item>
+                   <layout class="QHBoxLayout" name="customBackgroundOpacityLayout">
+                    <property name="spacing">
+                     <number>9</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="customBackgroundImageOpacityLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Opacity</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSlider" name="customBackgroundImageOpacitySlider">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimum">
+                       <number>0</number>
+                      </property>
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="value">
+                       <number>100</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Orientation::Horizontal</enum>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="GUIMusicGroupBox">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
This PR adds an option to the "View" tab allowing the user to change the emulator's background image using a PNG, JPG, or GIF file. I created this PR to resolve issue #436; I hope you like it and find it useful.

Note: AI was used for code generation and research, but I have tested and validated the changes myself.



Messi background image:

<img width="1366" height="735" alt="mesi" src="https://github.com/user-attachments/assets/807c818b-8c3c-4055-99e5-6616459b246b" />


Earth GIF:

<img width="1063" height="613" alt="EARTH" src="https://github.com/user-attachments/assets/1801ef0b-b914-47fa-83c0-31c28121e5b6" />
